### PR TITLE
fix(user-profile): Enforce authentication for profile gathering.

### DIFF
--- a/app/routes/User.routes.ts
+++ b/app/routes/User.routes.ts
@@ -28,5 +28,5 @@ export const UserRoute: express.Router = express
     .post('/:id/stats', asyncErrorHandler(UserStatsController.create))
     .get('/stats/coins', asyncErrorHandler(UserStatsController.getCoins))
     .get('/:id/stats/game', asyncErrorHandler(UserGameStatsController.forUser))
-    .get('/:id/profile', asyncErrorHandler(UserProfileController.show))
+    .get('/:id/profile', [mustBeAuthenticated, mustOwnUser], asyncErrorHandler(UserProfileController.show))
     .patch('/:id/profile', [mustBeAuthenticated, mustOwnUser], asyncErrorHandler(UserProfileController.update));


### PR DESCRIPTION
### Overview
Ensure that a user can only get there profile (authenticated) or the current authenticated admin can retrieve the given user's profile. This removes an existing bug that could expose existing profiles to the public.