### PR TITLE
fix(production): production build no longer fails

### DIFF
--- a/config/Database.ts
+++ b/config/Database.ts
@@ -12,7 +12,7 @@ const dbConfig = {
 
 let connection: Promise<Connection>;
 connection = createConnection({
-    entities: [__dirname + '/../app/models/*.ts'],
+    entities: [__dirname + '/../app/models/*{.ts,.js}'],
     type: 'postgres',
     database: dbConfig.NAME,
     host: dbConfig.HOST,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9770,9 +9770,9 @@
             }
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+            "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
         },
         "uc.micro": {
             "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "token-extractor": "^0.1.6",
         "ts-node": "^7.0.0",
         "typeorm": "^0.2.19",
-        "typescript": "^2.6.2"
+        "typescript": "^3.6.3"
     },
     "devDependencies": {
         "@hapi/joi": "^15.1.1",


### PR DESCRIPTION
Fixed a production build issue related to an out of date typescript version and up to date module versions clashing. Additionally updated the database configuration to allow for .ts or .js file extension models (dev and production).