### PR TITLE
Game Schedule Emails & Deduplication & Improved Log Management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ FRONT_URL=http://localhost:3000
 API_URL=http://localhost:8080
 
 AUTH_SECRET=secret
+LOG_LEVEL=info
 
 DISCORD_CLIENT=
 DISCORD_SECRET=

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
-import logger from './utils/logger';
-
 dotenv.config();
+
+import logger from './utils/logger';
 
 import * as cluster from 'cluster';
 import { cpus } from 'os';
@@ -11,8 +11,6 @@ import { config } from '../config';
 
 // tslint:disable-next-line: no-var-requires
 const project = require('../package');
-
-dotenv.config();
 
 /**
  * Called when a error occurring within the http server.

--- a/app/mail/game-application.mjml
+++ b/app/mail/game-application.mjml
@@ -1,0 +1,23 @@
+<mjml>
+  <mj-body background-color="#090b11">
+    <mj-include path="./layouts/header.mjml"></mj-include>
+
+    <mj-section>
+      <mj-column>
+        <mj-text font-weight="bold" align="center" font-size="24px" color="#fff" font-family="helvetica">Game Application: __GAME_TITLE__!</mj-text>
+        <mj-text align="center" line-height="160%" font-size="16px" color="#fff" font-family="helvetica">
+          Thank you for applying <strong>__USERNAME__</strong>! We received your application for the <strong>__GAME_MODE__</strong> game mode.
+          The game will be taking place on __GAME_TIME__. Be sure to check the rules and information about this mode and keep a eye out for DevWars going live!
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-top="0">
+      <mj-column>
+        <mj-button href="https://www.devwars.tv/docs#game-modes" background-color="#00c9ff" color="#090b11" border-radius="40px" font-family="helvetica" font-size="18px" font-weight="bold">GAME MODES</mj-button>
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="./layouts/footer.mjml"></mj-include>
+  </mj-body>
+</mjml>

--- a/app/mail/layouts/footer.mjml
+++ b/app/mail/layouts/footer.mjml
@@ -19,7 +19,8 @@
           </mj-social>
         </mj-column>
         <mj-column width="100%">
-          <mj-text align="center" color="#c9d0df" text-transform="uppercase">&copy; <a style="text-decoration: none; color: inherit;" href="#">DEVWARS.TV</a> - 2019</mj-text>
+          <mj-text align="center" color="#c9d0df" text-transform="uppercase">&copy; <a style="text-decoration: none; color: inherit;" href="https://www.devwars.tv/">DEVWARS.TV</a> - 2019</mj-text>
+          <mj-text align="center" color="#c9d0df"><a style="text-decoration: none; color: inherit;" href="https://discord.gg/devwars">Join our Discord!</a></mj-text>
         </mj-column>
       </mj-section>
     </mj-wrapper>

--- a/app/middleware/GameApplication.middleware.ts
+++ b/app/middleware/GameApplication.middleware.ts
@@ -1,0 +1,59 @@
+import { NextFunction, Response } from 'express';
+import { getCustomRepository } from 'typeorm';
+import * as _ from 'lodash';
+
+import GameScheduleRepository from '../repository/GameSchedule.repository';
+import { IGameRequest, IScheduleRequest } from '../request/IRequest';
+import GameRepository from '../repository/Game.repository';
+
+/**
+ * Ensures that the requesting authorized user has provided a valid schedule id, this id will be validated,
+ * gathered and bound to the request. Allowing future requests that implement this interface to
+ * pull the schedule from the request object.
+ */
+export const bindGameScheduleFromParam = async (request: IScheduleRequest, response: Response, next: NextFunction) => {
+    const { schedule: scheduleId } = request.params;
+
+    if (_.isNil(scheduleId)) {
+        return response.status(400).json({ error: 'Invalid schedule id provided.' });
+    }
+
+    const gameScheduleRepository = getCustomRepository(GameScheduleRepository);
+    const schedule = await gameScheduleRepository.findOne(scheduleId, { relations: ['game'] });
+
+    if (_.isNil(schedule)) {
+        return response.sendStatus(404).json({
+            error: 'A game schedule does not exist for the given id.',
+        });
+    }
+
+    request.schedule = schedule;
+    return next();
+};
+
+/**
+ * Ensures that the requesting authorized user has provided a valid schedule id, this id will be validated,
+ * gathered and bound to the request. Allowing future requests that implement this interface to
+ * pull the schedule from the request object.
+ */
+export const bindGameFromParam = async (request: IGameRequest, response: Response, next: NextFunction) => {
+    const { game: gameId } = request.params;
+
+    if (_.isNil(gameId)) {
+        return response.status(400).json({
+            error: 'Invalid game id provided.',
+        });
+    }
+
+    const gameRepository = getCustomRepository(GameRepository);
+    const game = await gameRepository.findOne(gameId, { relations: ['schedule'] });
+
+    if (_.isNil(game)) {
+        return response.status(404).json({
+            error: 'A game does not exist by the provided game id.',
+        });
+    }
+
+    request.game = game;
+    return next();
+};

--- a/app/models/Game.ts
+++ b/app/models/Game.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
 import BaseModel from './BaseModel';
 import GameSchedule from './GameSchedule';
 
@@ -50,6 +50,7 @@ export default class Game extends BaseModel {
     // ------------------------------------------------------------
     // Relations
 
-    @OneToOne((type) => GameSchedule, { cascade: true })
+    @JoinColumn()
+    @OneToOne(() => GameSchedule, { cascade: true })
     public schedule: GameSchedule;
 }

--- a/app/models/GameApplication.ts
+++ b/app/models/GameApplication.ts
@@ -7,9 +7,21 @@ import User from './User';
 
 @Entity('game_application')
 export default class GameApplication extends BaseModel {
-    @ManyToOne((type) => GameSchedule, (schedule) => schedule.applications, { onDelete: 'CASCADE' })
+    @ManyToOne(() => GameSchedule, (schedule) => schedule.applications, { onDelete: 'CASCADE' })
     public schedule: GameSchedule;
 
-    @ManyToOne((type) => User, (user) => user.applications)
+    @ManyToOne(() => User, (user) => user.applications)
     public user: User;
+
+    /**
+     * Creates a new instance of the game application instance.
+     * @param gameSchedule The game schedule that the user is applying to.
+     * @param user The user who is applying to the game schedule.
+     */
+    constructor(gameSchedule?: GameSchedule, user?: User) {
+        super();
+
+        this.schedule = gameSchedule;
+        this.user = user;
+    }
 }

--- a/app/models/GameSchedule.ts
+++ b/app/models/GameSchedule.ts
@@ -23,10 +23,10 @@ export default class GameSchedule extends BaseModel {
     // ------------------------------------------------------------
     // Relations
 
-    @OneToOne((type) => Game, { onDelete: 'CASCADE' })
     @JoinColumn()
+    @OneToOne(() => Game, { onDelete: 'CASCADE' })
     public game: Game;
 
-    @OneToMany((type) => GameApplication, (applications) => applications.schedule, { cascade: true })
+    @OneToMany(() => GameApplication, (applications) => applications.schedule, { cascade: true })
     public applications: GameApplication;
 }

--- a/app/request/IRequest.ts
+++ b/app/request/IRequest.ts
@@ -1,11 +1,29 @@
 import { Request } from 'express';
 
 import User from '../models/User';
+import GameSchedule from '../models/GameSchedule';
+import Game from '../models/Game';
 
 /**
- * Extends the default express request to contain a localized object of the devwars user, this will
+ * Extends the default express request to contain a localized object of the DevWars user, this will
  * be pushed on during the authentication process. And accessible if required.
  */
 export interface IRequest extends Request {
     user: User;
+}
+
+/**
+ * Extends the default express request to contain a localized object of the DevWars game schedule, this will
+ * be pushed on during the requests that specify the schedule id in the url. And accessible if required.
+ */
+export interface IScheduleRequest extends Request {
+    schedule: GameSchedule;
+}
+
+/**
+ * Extends the default express request to contain a localized object of the DevWars game, this will
+ * be pushed on during the requests that specify the game id in the url. And accessible if required.
+ */
+export interface IGameRequest extends Request {
+    game: Game;
 }

--- a/app/routes/Game.routes.ts
+++ b/app/routes/Game.routes.ts
@@ -6,6 +6,7 @@ import * as GameController from '../controllers/game/Game.controller';
 import { mustBeRole, mustBeAuthenticated } from '../middleware/Auth.middleware';
 import { isTwitchBot } from '../middleware/isTwitchBot.middleware';
 
+import { bindGameFromParam } from '../middleware/GameApplication.middleware';
 import { asyncErrorHandler } from './handlers';
 import { UserRole } from '../models/User';
 
@@ -16,39 +17,43 @@ GameRoute.get('/', asyncErrorHandler(GameController.all));
 GameRoute.post('/', [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)], asyncErrorHandler(GameController.create));
 GameRoute.get('/latest', asyncErrorHandler(GameController.latest));
 GameRoute.get('/active', asyncErrorHandler(GameController.active));
-GameRoute.get('/:id', asyncErrorHandler(GameController.show));
+GameRoute.get('/:game', [bindGameFromParam], asyncErrorHandler(GameController.show));
 
 GameRoute.patch(
-    '/:id',
-    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)],
+    '/:game',
+    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR), bindGameFromParam],
     asyncErrorHandler(GameController.update)
 );
 
-GameRoute.delete('/:id', [mustBeAuthenticated, mustBeRole(UserRole.ADMIN)], asyncErrorHandler(GameController.remove));
+GameRoute.delete(
+    '/:game',
+    [mustBeAuthenticated, mustBeRole(UserRole.ADMIN), bindGameFromParam],
+    asyncErrorHandler(GameController.remove)
+);
 
 GameRoute.post(
-    '/:id/activate',
-    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)],
+    '/:game/activate',
+    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR), bindGameFromParam],
     asyncErrorHandler(GameController.activate)
 );
 
 GameRoute.post(
-    '/:id/end',
-    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)],
+    '/:game/end',
+    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR), bindGameFromParam],
     asyncErrorHandler(LiveGameController.end)
 );
 
-GameRoute.post('/:id/end/bot', isTwitchBot, asyncErrorHandler(LiveGameController.end));
+GameRoute.post('/:game/end/bot', [isTwitchBot, bindGameFromParam], asyncErrorHandler(LiveGameController.end));
 
 GameRoute.post(
-    '/:id/player',
-    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)],
+    '/:game/player',
+    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR), bindGameFromParam],
     asyncErrorHandler(LiveGameController.addPlayer)
 );
 
 GameRoute.delete(
-    '/:id/player',
-    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)],
+    '/:game/player',
+    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR), bindGameFromParam],
     asyncErrorHandler(LiveGameController.removePlayer)
 );
 

--- a/app/routes/GameApplication.routes.ts
+++ b/app/routes/GameApplication.routes.ts
@@ -1,13 +1,46 @@
 import * as express from 'express';
+
 import * as GameApplicationController from '../controllers/game/GameApplication.controller';
+import { bindGameFromParam, bindGameScheduleFromParam } from '../middleware/GameApplication.middleware';
 import { mustBeAuthenticated } from '../middleware/Auth.middleware';
 import { asyncErrorHandler } from './handlers';
 
-export const GameApplicationRoute: express.Router = express
-    .Router()
-    .get('/mine', mustBeAuthenticated, asyncErrorHandler(GameApplicationController.mine))
-    .get('/game/:game', asyncErrorHandler(GameApplicationController.findByGame))
-    .get('/schedule/:schedule', asyncErrorHandler(GameApplicationController.findBySchedule))
-    .post('/schedule/:schedule', mustBeAuthenticated, asyncErrorHandler(GameApplicationController.apply))
-    .delete('/schedule/:schedule', mustBeAuthenticated, asyncErrorHandler(GameApplicationController.resign))
-    .post('/game/:game/username/:username', mustBeAuthenticated, asyncErrorHandler(GameApplicationController.create));
+const GameApplicationRoute: express.Router = express.Router();
+
+GameApplicationRoute.get(
+    '/mine',
+    mustBeAuthenticated,
+    asyncErrorHandler(GameApplicationController.getCurrentUserGameApplications)
+);
+
+GameApplicationRoute.get(
+    '/game/:game',
+    [bindGameFromParam],
+    asyncErrorHandler(GameApplicationController.findUserApplicationsByGame)
+);
+
+GameApplicationRoute.get(
+    '/schedule/:schedule',
+    [bindGameScheduleFromParam],
+    asyncErrorHandler(GameApplicationController.findApplicationsBySchedule)
+);
+
+GameApplicationRoute.post(
+    '/schedule/:schedule',
+    [mustBeAuthenticated, bindGameScheduleFromParam],
+    asyncErrorHandler(GameApplicationController.applyToSchedule)
+);
+
+GameApplicationRoute.delete(
+    '/schedule/:schedule',
+    [mustBeAuthenticated, bindGameScheduleFromParam],
+    asyncErrorHandler(GameApplicationController.resignFromSchedule)
+);
+
+GameApplicationRoute.post(
+    '/game/:game/username/:username',
+    [mustBeAuthenticated, bindGameFromParam],
+    asyncErrorHandler(GameApplicationController.createGameSchedule)
+);
+
+export { GameApplicationRoute };

--- a/app/services/Connection.service.ts
+++ b/app/services/Connection.service.ts
@@ -1,9 +1,5 @@
-import * as dotenv from 'dotenv';
-
 import { config, DIALECT } from '../../config';
 import { Connection, createConnection } from 'typeorm';
-
-dotenv.config();
 
 let connection: Promise<Connection>;
 connection = createConnection({

--- a/app/services/Mail.service.ts
+++ b/app/services/Mail.service.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as createMailgun from 'mailgun-js';
 
+import GameApplication from '../models/GameApplication';
 import logger from '../utils/logger';
 import User from '../models/User';
 
@@ -16,7 +17,7 @@ export async function send(to: string, subject: string, html: string) {
 
     // If we are in development of the application, we would want to look to log out the details as
     // these could be used for testing validation links, and email information in development.
-    if (process.env.NODE_ENV === 'development') return logger.info({ to, subject, html });
+    if (process.env.NODE_ENV === 'development') return logger.info(`to: ${to}, subject: ${subject}, html: ${html}`);
 
     try {
         const mailgun = createMailgun({ apiKey: process.env.MAILGUN_KEY, domain: 'devwars.tv' });
@@ -45,6 +46,28 @@ export async function sendWelcomeEmail(user: User, verificationUrl: string) {
         .replace(/__URL__/g, verificationUrl);
 
     await send(user.email, subject, output.html);
+}
+
+/**
+ * Sends the game application applying email to the given user, this email describes
+ * the game they are applying to with basic information about the event.
+ * @param gameApplication The game application related to the email being sent.
+ */
+export async function sendGameApplicationApplyingEmail(gameApplication: GameApplication) {
+    const subject = 'DevWars Game Application';
+
+    const filePath = path.resolve(__dirname, '../mail/game-application.mjml');
+    const template = fs.readFileSync(filePath).toString();
+    const output = mjml2html(template, { ...mjmlOptions, filePath });
+
+    // prettier-ignore
+    output.html = output.html
+        .replace(/__USERNAME__/g, gameApplication.user.username)
+        .replace(/__GAME_TITLE__/g, gameApplication.schedule.game.title)
+        .replace(/__GAME_TIME__/g, gameApplication.schedule.startTime.toUTCString())
+        .replace(/__GAME_MODE__/g, `${gameApplication.schedule.game.mode}`);
+
+    await send(gameApplication.user.email, subject, output.html);
 }
 
 export async function sendPasswordResetEmail(user: User, resetUrl: string) {

--- a/app/services/Server.service.ts
+++ b/app/services/Server.service.ts
@@ -52,7 +52,7 @@ export default class ServerService {
         const routeLogging = morgan('combined', {
             stream: {
                 write: (text: string) => {
-                    logger.info(text.replace(/\n$/, ''));
+                    logger.verbose(text.replace(/\n$/, ''));
                 },
             },
         });

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -1,5 +1,8 @@
 import * as fs from 'fs';
+import * as dotenv from 'dotenv';
 import * as winston from 'winston';
+
+dotenv.config();
 
 const { colorize, combine, timestamp, printf, splat } = winston.format;
 
@@ -42,13 +45,19 @@ const logger = winston.createLogger({
     format: combine(timestamp(), splat(), myFormat),
     transports: [
         new winston.transports.File({ filename: './logs/error.log', level: 'warn', maxsize: 2e6, maxFiles: 3 }),
-        new winston.transports.File({ filename: './logs/all.log', maxsize: 2e6, maxFiles: 3 }),
+        new winston.transports.File({
+            filename: './logs/all.log',
+            level: process.env.LOG_LEVEL || 'info',
+            maxsize: 2e6,
+            maxFiles: 3,
+        }),
     ],
 });
 
 logger.add(
     new winston.transports.Console({
         format: combine(timestamp(), colorize(), splat(), myFormat),
+        level: process.env.LOG_LEVEL || 'info',
     })
 );
 


### PR DESCRIPTION
### Overview
This pull request overs emailing through user game applications, api simplification by removing duplicate code and improved logging.

#### Schedule Emailing
When a user applies to play for a game from the game schedule list, an email will be sent out ensuring that they are aware that we have recieved the application + information about the game, mode and time will also be sent.

![image](https://user-images.githubusercontent.com/12329422/68546772-121b0e80-03d2-11ea-9724-c6b47d371e14.png)

This includes an updated footer with discord + devwars.tv linked.

#### Binding of game and schedule
The game's and schedules are now being bound to the request object through the middleware, allowing for the simplification of the requests. If the :game or :schedule is specified and the binding middleware is used. Then the IGame or ISchedule request interfaces can be specified for the request to gain access.

If the request makes it through the middleware, you can ensure that the object exists. 

#### Logging
Log level for console and 'all' file-based logging can now be specified through the .env file. Falling back to info if non is specified. All warnings and below will still be captured. The testing process and default running of the application will be less noisy since the requests now come under 'verbose" which by default will not be logged to the console.