### PR TITLE
feature: binding user object by id via a middleware

### DIFF
--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -6,6 +6,10 @@ export const USERNAME_MAX_LENGTH = 25;
 // Does not allow special characters in the beginning or end of username
 export const USERNAME_REGEX = /^[a-zA-Z0-9.-][A-z0-9.-_]{2,23}[a-zA-Z0-9.-]$/;
 
+// currently postgres max int is 4 bytes and any attempt to go over this limit should be rejected
+// http://www.postgresqltutorial.com/postgresql-integer/
+export const DATABASE_MAX_ID = 2 ** 31 - 1;
+
 // Username limits in regards for twitch when processing requests that is directly related to the
 // twitch username. e.g updating twitch coins.
 export const TWITCH_USERNAME_MIN_LENGTH = 4;

--- a/app/controllers/user/User.controller.ts
+++ b/app/controllers/user/User.controller.ts
@@ -5,7 +5,7 @@ import { isNil } from 'lodash';
 import User from '../../models/User';
 import { UserRole } from '../../models/User';
 import UserRepository from '../../repository/User.repository';
-import { IRequest } from '../../request/IRequest';
+import { IRequest, IUserRequest } from '../../request/IRequest';
 import { hash } from '../../utils/hash';
 
 interface IUpdateUserRequest {
@@ -17,27 +17,117 @@ interface IUpdateUserRequest {
     token: string;
 }
 
-export async function show(request: Request, response: Response) {
-    const user = await User.findOne(request.params.id);
-
-    if (isNil(user)) return response.status(404).json({ error: 'User does not exist by the provided id.' });
-    const sanitizedUser = user.sanitize('email', 'lastSignIn', 'createdAt', 'updatedAt');
-
+/**
+ * @api {get} /:user Request User basic information
+ * @apiName GetUserById
+ * @apiGroup User
+ *
+ * @apiParam {Number} user Users unique ID.
+ *
+ * @apiSuccess {string} username    the username of the User.
+ * @apiSuccess {string} role        the role of the User.
+ * @apiSuccess {number} id          the id of the User.
+ * @apiSuccess {string} avatarUrl   the avatar url of the User.
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 200 OK
+ *     {
+ *      "username": "test-admin",
+ *      "role": "ADMIN",
+ *      "id": 1,
+ *      "avatarUrl": "http://lorempixel.com/640/480/nature"
+ *    }
+ */
+export async function show(request: IUserRequest, response: Response) {
+    const sanitizedUser = request.boundUser.sanitize('email', 'lastSignIn', 'createdAt', 'updatedAt');
     return response.json(sanitizedUser);
 }
 
+/**
+ * @api {get} /:user Request All User basic information
+ * @apiName GetUsers
+ * @apiGroup User
+ * @apiPermission administrator
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 200 OK
+ *     [{
+ *      "username": "test-admin",
+ *      "role": "ADMIN",
+ *      "id": 1,
+ *      "avatarUrl": "http://lorempixel.com/640/480/nature"
+ *      "updatedAt": "2019-11-19T14:54:09.441Z",
+ *      "createdAt": "2019-11-19T14:54:09.441Z",
+ *      "lastSignIn": "2019-11-19T14:54:09.442Z",
+ *     },
+ *     {
+ *      "username": "Lelia_Boyer",
+ *      "email": "William_Rowe1@yahoo.com",
+ *      "role": "MODERATOR",
+ *      "id": 5,
+ *      "updatedAt": "2019-11-19T14:54:09.479Z",
+ *      "createdAt": "2019-11-19T14:54:09.479Z",
+ *      "lastSignIn": "2019-11-19T14:54:09.481Z",
+ *      "avatarUrl": "http://lorempixel.com/640/480/cats"
+ *     }]
+ */
 export async function all(request: Request, response: Response) {
     const users = await User.find();
     return response.json(users);
 }
 
-export async function update(request: IRequest, response: Response) {
+/**
+ * @api {post} /:user Updates User basic information
+ * @apiName UpdateUserById
+ * @apiGroup User
+ * @apiPermission moderator, owner
+ *
+ * @apiParam {Number} user Users unique ID.
+ * @apiParam {string} [username] Users updated username.
+ * @apiParam {string} [email] Users updated email.
+ * @apiParam {string} [password] Users updated password.
+ * @apiParam {string} [role] Users updated role.
+ * @apiParam {string} [token] Users updated token.
+ * @apiParam {string} [lastSigned] Users updated last signed in date.
+ *
+ * @apiParamExample {json} Request-Example:
+ *     {
+ *      "username": "test-admin",
+ *      "email": "test-admin@example.com",
+ *      "password": "password",
+ *      "token": "token",
+ *      "role": "ADMIN",
+ *      "lastSigned": "2019-11-20T15:51:24.690Z",
+ *     }
+ *
+ * @apiSuccess {string} username    the username of the User.
+ * @apiSuccess {string} role        the role of the User.
+ * @apiSuccess {number} id          the id of the User.
+ * @apiSuccess {string} avatarUrl   the avatar url of the User.
+ * @apiSuccess {datetime} updatedAt the time the user was last updated.
+ * @apiSuccess {datetime} createdAt the time the user was created at.
+ * @apiSuccess {datetime} lastSignIn the time the user last signed in.
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 200 OK
+ *     {
+ *      "username": "test-admin",
+ *      "email": "test-admin@example.com",
+ *      "role": "ADMIN",
+ *      "id": 1,
+ *      "avatarUrl": "http://lorempixel.com/640/480/nature"
+ *      "updatedAt": "2019-11-19T14:54:09.441Z",
+ *      "createdAt": "2019-11-19T14:54:09.441Z",
+ *      "lastSignIn": "2019-11-19T14:54:09.442Z",
+ *     }
+ */
+export async function update(request: IUserRequest, response: Response) {
     const params = request.body as IUpdateUserRequest;
 
     const userRepository = getCustomRepository(UserRepository);
     const existingUsername = await userRepository.findByUsername(params.username);
 
-    if (!isNil(existingUsername) && existingUsername.id !== request.user.id) {
+    if (!isNil(existingUsername) && existingUsername.id !== request.boundUser.id) {
         return response.status(409).send({
             message: 'The provided username already exists for a registered user.',
         });
@@ -46,8 +136,8 @@ export async function update(request: IRequest, response: Response) {
     // Ensure to encrypt the updated password if it has been specified.
     if (!isNil(params.password)) params.password = await hash(params.password);
 
-    Object.assign(request.user, params);
-    await request.user.save();
+    Object.assign(request.boundUser, params);
+    await request.boundUser.save();
 
-    return response.json(request.user);
+    return response.json(request.boundUser);
 }

--- a/app/controllers/user/UserAvatar.controller.ts
+++ b/app/controllers/user/UserAvatar.controller.ts
@@ -1,14 +1,14 @@
 import { Response } from 'express';
 
 import { AvatarService } from '../../services/Avatar.service';
-import { IRequest } from '../../request/IRequest';
+import { IUserRequest } from '../../request/IRequest';
 
-export async function store(request: IRequest, response: Response) {
+export async function store(request: IUserRequest, response: Response) {
     try {
-        await AvatarService.updateAvatarForUser(request.user, request.file.path);
+        await AvatarService.updateAvatarForUser(request.boundUser, request.file.path);
     } catch (e) {
         return response.status(400).json({ error: "We couldn't upload your avatar" });
     }
 
-    return response.json(request.user);
+    return response.json(request.boundUser);
 }

--- a/app/controllers/user/UserGameStats.controller.ts
+++ b/app/controllers/user/UserGameStats.controller.ts
@@ -2,12 +2,10 @@ import { Request, Response } from 'express';
 import { getCustomRepository } from 'typeorm';
 
 import UserRepository from '../../repository/User.repository';
+import { IUserRequest } from '../../request/IRequest';
 
-export async function forUser(request: Request, response: Response) {
+export async function forUser(request: IUserRequest, response: Response) {
     const userRepository = getCustomRepository(UserRepository);
-    const user = await userRepository.findOne(request.params.id);
-    if (!user) return response.sendStatus(404);
-
-    const stats = await userRepository.findGameStatsByUser(user);
+    const stats = await userRepository.findGameStatsByUser(request.boundUser);
     return response.json(stats);
 }

--- a/app/middleware/Auth.middleware.ts
+++ b/app/middleware/Auth.middleware.ts
@@ -65,7 +65,7 @@ export const mustBeRoleOrOwner = (role?: UserRole, bot: boolean = false) => asyn
     response: Response,
     next: NextFunction
 ) => {
-    const requestedUserId = Number(request.params.id);
+    const requestedUserId = Number(request.params.user);
 
     // Ensure that the requesting user is the entity they are also trying to perform the following
     // request on. For example: you can only update your own profile and not others (unless your a admin).

--- a/app/middleware/GameApplication.middleware.ts
+++ b/app/middleware/GameApplication.middleware.ts
@@ -2,9 +2,9 @@ import { NextFunction, Response } from 'express';
 import { getCustomRepository } from 'typeorm';
 import * as _ from 'lodash';
 
-import GameScheduleRepository from '../repository/GameSchedule.repository';
-import { IGameRequest, IScheduleRequest } from '../request/IRequest';
+import { IGameRequest } from '../request/IRequest';
 import GameRepository from '../repository/Game.repository';
+import { DATABASE_MAX_ID } from '../constants';
 
 /**
  * Ensures that the requesting authorized user has provided a valid schedule id, this id will be validated,
@@ -14,7 +14,7 @@ import GameRepository from '../repository/Game.repository';
 export const bindGameFromGameParam = async (request: IGameRequest, response: Response, next: NextFunction) => {
     const { game: gameId } = request.params;
 
-    if (_.isNil(gameId)) {
+    if (_.isNil(gameId) || isNaN(_.toNumber(gameId)) || Number(gameId) > DATABASE_MAX_ID) {
         return response.status(400).json({
             error: 'Invalid game id provided.',
         });

--- a/app/middleware/GameSchedule.middleware.ts
+++ b/app/middleware/GameSchedule.middleware.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 
 import GameScheduleRepository from '../repository/GameSchedule.repository';
 import { IScheduleRequest } from '../request/IRequest';
+import { DATABASE_MAX_ID } from '../constants';
 
 /**
  * Ensures that the requesting authorized user has provided a valid schedule id, this id will be validated,
@@ -17,7 +18,7 @@ export const bindScheduleFromScheduleParam = async (
 ) => {
     const { schedule: scheduleId } = request.params;
 
-    if (_.isNil(scheduleId)) {
+    if (_.isNil(scheduleId) || isNaN(_.toNumber(scheduleId)) || Number(scheduleId) > DATABASE_MAX_ID) {
         return response.status(400).json({ error: 'Invalid schedule id provided.' });
     }
 

--- a/app/middleware/User.middleware.ts
+++ b/app/middleware/User.middleware.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Response } from 'express';
+import { getCustomRepository } from 'typeorm';
+import * as _ from 'lodash';
+
+import { IUserRequest } from '../request/IRequest';
+import UserRepository from '../repository/User.repository';
+
+/**
+ * Ensures that the requesting authorized user has provided a valid schedule id, this id will be validated,
+ * gathered and bound to the request. Allowing future requests that implement this interface to
+ * pull the schedule from the request object.
+ */
+export const bindUserFromUserParam = async (request: IUserRequest, response: Response, next: NextFunction) => {
+    const { user: userId } = request.params;
+
+    if (_.isNil(userId) || isNaN(_.toNumber(userId))) {
+        return response.status(400).json({ error: 'Invalid user id provided.' });
+    }
+
+    const userRepository = getCustomRepository(UserRepository);
+    const user = await userRepository.findById(userId);
+
+    if (_.isNil(user)) {
+        return response.status(404).json({
+            error: 'A user does not exist for the given id.',
+        });
+    }
+
+    request.boundUser = user;
+    return next();
+};

--- a/app/middleware/User.middleware.ts
+++ b/app/middleware/User.middleware.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 
 import { IUserRequest } from '../request/IRequest';
 import UserRepository from '../repository/User.repository';
+import { DATABASE_MAX_ID } from '../constants';
 
 /**
  * Ensures that the requesting authorized user has provided a valid schedule id, this id will be validated,
@@ -13,7 +14,7 @@ import UserRepository from '../repository/User.repository';
 export const bindUserFromUserParam = async (request: IUserRequest, response: Response, next: NextFunction) => {
     const { user: userId } = request.params;
 
-    if (_.isNil(userId) || isNaN(_.toNumber(userId))) {
+    if (_.isNil(userId) || isNaN(_.toNumber(userId)) || Number(userId) > DATABASE_MAX_ID) {
         return response.status(400).json({ error: 'Invalid user id provided.' });
     }
 

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToMany, OneToOne } from 'typeorm';
+import { Entity, Column, OneToMany, OneToOne, JoinColumn } from 'typeorm';
 import BaseModel from './BaseModel';
 import LinkedAccount from './LinkedAccount';
 import Activity from './Activity';
@@ -51,13 +51,22 @@ export default class User extends BaseModel {
     @OneToOne((type) => EmailVerification)
     public verification: EmailVerification;
 
-    @OneToMany((type) => Activity, (activities) => activities.user)
+    @OneToMany(
+        (type) => Activity,
+        (activities) => activities.user
+    )
     public activities: Activity;
 
-    @OneToMany((type) => GameApplication, (applications) => applications.user)
+    @OneToMany(
+        (type) => GameApplication,
+        (applications) => applications.user
+    )
     public applications: GameApplication;
 
-    @OneToMany((type) => LinkedAccount, (accounts) => accounts.user)
+    @OneToMany(
+        (type) => LinkedAccount,
+        (accounts) => accounts.user
+    )
     public accounts: LinkedAccount[];
 
     /**

--- a/app/request/IRequest.ts
+++ b/app/request/IRequest.ts
@@ -13,6 +13,15 @@ export interface IRequest extends Request {
 }
 
 /**
+ * Extends the default express request to contain a localized object of the DevWars user, this will
+ * be pushed on during the binding middleware stage when specified as a middleware and the user param
+ * is specified. process. And accessible if required.
+ */
+export interface IUserRequest extends Request {
+    boundUser: User;
+}
+
+/**
  * Extends the default express request to contain a localized object of the DevWars game schedule, this will
  * be pushed on during the requests that specify the schedule id in the url. And accessible if required.
  */

--- a/app/routes/User.routes.ts
+++ b/app/routes/User.routes.ts
@@ -7,44 +7,56 @@ import * as UserStatsController from '../controllers/user/UserStats.controller';
 import * as UserGameStatsController from '../controllers/user/UserGameStats.controller';
 import * as UserAvatarController from '../controllers/user/UserAvatar.controller';
 
-import User, { UserRole } from '../models/User';
+import { UserRole } from '../models/User';
 import { mustBeRole, mustBeAuthenticated, mustBeRoleOrOwner } from '../middleware/Auth.middleware';
 import { asyncErrorHandler } from './handlers';
 import { bodyValidation } from './validators';
 import { statsSchema, profileSchema, updateUserSchema } from './validators/user.validator';
+import { bindUserFromUserParam } from '../middleware/User.middleware';
 
 const upload = multer({ dest: 'uploads/' });
 const UserRoute: express.Router = express.Router();
 
 UserRoute.get('/', [mustBeAuthenticated, mustBeRole(UserRole.ADMIN)], asyncErrorHandler(UserController.all));
-UserRoute.get('/:id', asyncErrorHandler(UserController.show));
+UserRoute.get('/:user', [bindUserFromUserParam], asyncErrorHandler(UserController.show));
 
 UserRoute.put(
-    '/:id',
-    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.MODERATOR), bodyValidation(updateUserSchema)],
+    '/:user',
+    [
+        mustBeAuthenticated,
+        mustBeRoleOrOwner(UserRole.MODERATOR),
+        bindUserFromUserParam,
+        bodyValidation(updateUserSchema),
+    ],
     asyncErrorHandler(UserController.update)
 );
 
 UserRoute.put(
-    '/:id/avatar',
-    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.MODERATOR), upload.single('avatar')],
+    '/:user/avatar',
+    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.MODERATOR), bindUserFromUserParam, upload.single('avatar')],
     asyncErrorHandler(UserAvatarController.store)
 );
 
-UserRoute.get('/:id/stats', asyncErrorHandler(UserStatsController.forUser));
-UserRoute.post('/:id/stats', [bodyValidation(statsSchema)], asyncErrorHandler(UserStatsController.create));
+UserRoute.get('/:user/stats', [bindUserFromUserParam], asyncErrorHandler(UserStatsController.forUser));
+
+UserRoute.post(
+    '/:user/stats',
+    [bodyValidation(statsSchema), bindUserFromUserParam],
+    asyncErrorHandler(UserStatsController.create)
+);
+
 UserRoute.get('/stats/coins', asyncErrorHandler(UserStatsController.getCoins));
-UserRoute.get('/:id/stats/game', asyncErrorHandler(UserGameStatsController.forUser));
+UserRoute.get('/:user/stats/game', [bindUserFromUserParam], asyncErrorHandler(UserGameStatsController.forUser));
 
 UserRoute.get(
-    '/:id/profile',
-    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.MODERATOR)],
+    '/:user/profile',
+    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.MODERATOR), bindUserFromUserParam],
     asyncErrorHandler(UserProfileController.show)
 );
 
 UserRoute.patch(
-    '/:id/profile',
-    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.ADMIN), bodyValidation(profileSchema)],
+    '/:user/profile',
+    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.ADMIN), bodyValidation(profileSchema), bindUserFromUserParam],
     asyncErrorHandler(UserProfileController.update)
 );
 


### PR DESCRIPTION
### Overview
non-authenticated users can be bound to the request object via the bindUserFromUserParam onto the request object. This ensures that the given user exists and the given id is a actual number. Additionally if any middleware bound id greater than postgres int limit is rejected.

This can be later accessed via the IUserRequest object after binding from the middleware. Set for request.boundUser instead of request.user which is currently reserved for authenticated users.

 * Added api docs for the user.controller.