### PR TITLE
Registration does not allow existing username/email regardless of case.

### DIFF
--- a/app/controllers/authentication/Authentication.controller.ts
+++ b/app/controllers/authentication/Authentication.controller.ts
@@ -47,13 +47,13 @@ export async function register(request: Request, response: Response) {
     email = email.trim();
 
     const userRepository = getCustomRepository(UserRepository);
-    const existingUser = await userRepository.findOne({ where: [{ username }, { email }] });
+    const existingUser = await userRepository.findByUsernameOrEmail(username, email);
 
-    if (existingUser && existingUser.username === username) {
+    if (existingUser && existingUser.username.toLowerCase() === username.toLowerCase()) {
         return response.status(409).json({ error: 'A user already exists with the provided username.' });
     }
 
-    if (existingUser && existingUser.email === email) {
+    if (existingUser && existingUser.email.toLowerCase() === email.toLowerCase()) {
         return response.status(409).json({ error: 'A user already exists with the provided email.' });
     }
 

--- a/app/repository/User.repository.ts
+++ b/app/repository/User.repository.ts
@@ -22,18 +22,42 @@ export default class UserRepository extends Repository<User> {
         return await User.findOne({ where: { id } });
     }
 
+    /**
+     * Attempts to find a given user by the email.
+     * @param email The email of the given user.
+     */
     public findByEmail(email: string): Promise<User> {
         return User.createQueryBuilder()
             .where('LOWER(email) = LOWER(:email)', { email })
             .getOne();
     }
 
+    /**
+     * Attempts to find a user by a given username.
+     * @param username The username of the given user.
+     */
     public findByUsername(username: string): Promise<User> {
         return User.createQueryBuilder()
             .where('LOWER(username) = LOWER(:username)', { username })
             .getOne();
     }
 
+    /**
+     * Finds a given user by a email or username, ensuring that they are done lowercase.
+     * @param username The username of the given user.
+     * @param email The email of the given user.
+     */
+    public findByUsernameOrEmail(username: string, email: string): Promise<User> {
+        return User.createQueryBuilder()
+            .where('LOWER(username) = LOWER(:username)', { username })
+            .orWhere('LOWER(email) = LOWER(:email)', { email })
+            .getOne();
+    }
+
+    /**
+     * Finds the user by a given authentication token.
+     * @param token The authentication token for the given user.
+     */
     public findByToken(token: string): Promise<User> {
         return User.findOne({ where: { token } });
     }

--- a/app/seeding/User.seeding.ts
+++ b/app/seeding/User.seeding.ts
@@ -2,8 +2,6 @@ import * as bcrypt from 'bcrypt';
 import { helpers, random } from 'faker';
 import User, { UserRole } from '../models/User';
 
-import { USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH } from '../constants';
-
 export default class UserSeeding {
     public static default(): User {
         const userCard = helpers.userCard();

--- a/app/seeding/User.seeding.ts
+++ b/app/seeding/User.seeding.ts
@@ -2,12 +2,15 @@ import * as bcrypt from 'bcrypt';
 import { helpers, random } from 'faker';
 import User, { UserRole } from '../models/User';
 
+import { USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH } from '../constants';
+
 export default class UserSeeding {
     public static default(): User {
-        const usersHelperCard = helpers.userCard();
+        const userCard = helpers.userCard();
 
         const role = random.arrayElement([UserRole.PENDING, UserRole.ADMIN, UserRole.MODERATOR, UserRole.USER]);
-        const user = new User(usersHelperCard.username, bcrypt.hashSync('secret', 1), usersHelperCard.email, role);
+        const user = new User(userCard.username, bcrypt.hashSync('secret', 1), userCard.email, role);
+
         user.avatarUrl = random.image();
         user.lastSignIn = new Date();
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -2,7 +2,7 @@
     "watch": ["**/*.ts"],
     "ext": "ts",
     "ignore": ["./test/*.ts"],
-    "exec": "node --inspect -r ts-node/register ./app/index.ts --transpile-only",
+    "exec": "node --inspect -r ts-node/register ./app/index.ts",
     "env": {
         "NODE_ENV": "development"
     }


### PR DESCRIPTION
### General
When a user now registers with the system, the username and email will be checked against the system for existence, regardless of case. Ensuring that a user cannot register with a existing email or username.

There **will** exist users in the database with the same username but different cases, this happened in todays game with _diktat0ren_ since he has a account registered with _Diktat0ren_ and _diktat0ren_ (uppercase D) but can only login with the lowecase one. Probably since its the first returned.

You can use the following query to gather all users with the same username, we can then talk with said users and see what user they want to keep and remove the other. 

```sql
SELECT username FROM "user" WHERE UPPER(username) IN  (SELECT UPPER(username) FROM "user" GROUP BY UPPER(username) HAVING COUNT(*) > 1) ORDER BY username;
```

### Notes
 * removed transpile option that would stop ts errors
 * added supporting tests 