### PR TITLE
Feature/user lookup

### DIFF
--- a/app/routes/User.routes.ts
+++ b/app/routes/User.routes.ts
@@ -18,6 +18,13 @@ const upload = multer({ dest: 'uploads/' });
 const UserRoute: express.Router = express.Router();
 
 UserRoute.get('/', [mustBeAuthenticated, mustBeRole(UserRole.ADMIN)], asyncErrorHandler(UserController.all));
+
+UserRoute.get(
+    '/lookup',
+    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)],
+    asyncErrorHandler(UserController.lookupUser)
+);
+
 UserRoute.get('/:user', [bindUserFromUserParam], asyncErrorHandler(UserController.show));
 
 UserRoute.put(

--- a/package-lock.json
+++ b/package-lock.json
@@ -4280,9 +4280,9 @@
             }
         },
         "handlebars": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-            "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+            "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -1,0 +1,42 @@
+import { getManager, EntityManager, getCustomRepository } from 'typeorm';
+import * as supertest from 'supertest';
+import * as chai from 'chai';
+import * as _ from 'lodash';
+
+import { Connection } from '../app/services/Connection.service';
+import ServerService from '../app/services/Server.service';
+import { cookieForUser } from './helpers';
+import { UserRole } from '../app/models/User';
+import { UserSeeding } from '../app/seeding';
+
+const server: ServerService = new ServerService();
+let agent: any;
+
+const connectionManager: EntityManager = getManager();
+
+describe.only('user', () => {
+    before(async () => {
+        await server.Start();
+        await (await Connection).synchronize(true);
+    });
+
+    beforeEach(() => {
+        agent = supertest.agent(server.App());
+    });
+
+    describe('GET - /users/lookup - Performing username based like lookup', () => {
+        it('Should reject not authenticated.', async () => {
+            await agent.get('/users/lookup?username=test').expect(401);
+        });
+
+        it('Should reject not a minimum level of moderator.', async () => {
+            const user = await UserSeeding.withRole(UserRole.USER).save();
+
+            await agent
+                .get('/users/lookup?username=test')
+                .set('Cookie', await cookieForUser(user))
+                .send()
+                .expect(403);
+        });
+    });
+});

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -6,15 +6,13 @@ import * as _ from 'lodash';
 import { Connection } from '../app/services/Connection.service';
 import ServerService from '../app/services/Server.service';
 import { cookieForUser } from './helpers';
-import { UserRole } from '../app/models/User';
+import User, { UserRole } from '../app/models/User';
 import { UserSeeding } from '../app/seeding';
 
 const server: ServerService = new ServerService();
 let agent: any;
 
-const connectionManager: EntityManager = getManager();
-
-describe.only('user', () => {
+describe('user', () => {
     before(async () => {
         await server.Start();
         await (await Connection).synchronize(true);
@@ -24,19 +22,82 @@ describe.only('user', () => {
         agent = supertest.agent(server.App());
     });
 
-    describe('GET - /users/lookup - Performing username based like lookup', () => {
-        it('Should reject not authenticated.', async () => {
-            await agent.get('/users/lookup?username=test').expect(401);
+    describe('GET - /users/lookup?username=:username&limit=:limit - Performing username based like lookup', () => {
+        const lookupUrl = '/users/lookup?username=testing&limit=3';
+        let moderator: User = null;
+
+        beforeEach(async () => {
+            moderator = await UserSeeding.withRole(UserRole.MODERATOR).save();
         });
 
-        it('Should reject not a minimum level of moderator.', async () => {
+        it('Should reject not authenticated users.', async () => {
+            await agent.get(lookupUrl).expect(401);
+        });
+
+        it('Should reject users not a minimum role of moderator.', async () => {
             const user = await UserSeeding.withRole(UserRole.USER).save();
 
             await agent
-                .get('/users/lookup?username=test')
+                .get(lookupUrl)
                 .set('Cookie', await cookieForUser(user))
                 .send()
                 .expect(403);
+        });
+
+        it('Should allow moderator and admins.', async () => {
+            const admin = await UserSeeding.withRole(UserRole.ADMIN).save();
+
+            for (const test of [[moderator, 200], [admin, 200]]) {
+                await agent
+                    .get(lookupUrl)
+                    .set('Cookie', await cookieForUser(test[0] as User))
+                    .send()
+                    .expect(test[1]);
+            }
+        });
+
+        it('Should reject if the given username is not provided', async () => {
+            await agent
+                .get('/users/lookup')
+                .set('Cookie', await cookieForUser(moderator))
+                .send()
+                .expect(400, {
+                    message: 'The specified username within the query must not be empty.',
+                });
+        });
+
+        it('Should respect the limit if specified', async () => {
+            for (const test of [[50, 50], [1, 1], [10, 10], [500, 50]]) {
+                const response = await agent
+                    .get(`/users/lookup?username=e&limit=${test[0]}`)
+                    .set('Cookie', await cookieForUser(moderator))
+                    .send();
+
+                // less than or equal since user generation is not as expected and the results could
+                // diff based on seeding.
+                chai.expect(response.body.length <= test[1]).to.be.eq(true);
+            }
+        });
+
+        it("Should return related users when looking up 'testing'", async () => {
+            const users = ['one', 'two', 'three'];
+
+            for (const user of users) {
+                await UserSeeding.withUsername(`testing-${user}`).save();
+            }
+
+            const response = await agent
+                .get(lookupUrl)
+                .set('Cookie', await cookieForUser(moderator))
+                .send();
+
+            chai.expect(response.body.length).to.be.eq(3);
+
+            for (const user of response.body) {
+                chai.expect(users).to.include(user.username.split('-')[1]);
+                chai.expect(user.id).to.not.eq(undefined);
+                chai.expect(user.id).to.not.eq(null);
+            }
         });
     });
 });


### PR DESCRIPTION
### Overview
Basic username and Id can be looked up as a search query style format for given users within the system by using the lookup endpoint. Uses a like implementation with a hard limit of 50 and rejection of no username.

The lookup endpoint requires moderation level authentication and when provided with any partial username will return related matches (complete username and id). 

![image](https://user-images.githubusercontent.com/12329422/71186555-53c29300-2275-11ea-96c6-585bd0293308.png)

### Notes
* run npm audit fix to resolve security concerns.
* Tests coverage for user-lookup is increased, covering authentication, limits, results and role validation.
