### PR TITLE
Feature/contact us

### DIFF
--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -55,3 +55,11 @@ export const GAME_SCHEDULE_TITLE_MAX_LENGTH = 124;
 // The min and max length of a given description of a objective of the game.
 export const GAME_SCHEDULE_OBJECTIVE_DESCRIPTION_MIN_LENGTH = 5;
 export const GAME_SCHEDULE_OBJECTIVE_DESCRIPTION_MAX_LENGTH = 124;
+
+// The min and max length of the contact us name length
+export const CONTACT_US_NAME_MIN = 3;
+export const CONTACT_US_NAME_MAX = 64;
+
+// the min and max length of the contact message
+export const CONTACT_US_MESSAGE_MIN = 24;
+export const CONTACT_US_MESSAGE_MAX = 500;

--- a/app/controllers/contact.controller.ts
+++ b/app/controllers/contact.controller.ts
@@ -7,11 +7,21 @@ import { sendContactUsEmail } from '../services/Mail.service';
  * @apiVersion 1.0.0
  * @apiName ContactUs
  * @apiGroup Contact
+ *
+ * @apiParam {string} name The name of the requesting contact us person.
+ * @apiParam {string} email The email of the contact us person who will be getting the reply.
+ * @apiParam {string} message The message in the contact us request.
+ *
+ *  * @apiParamExample {json} Request-Example:
+ *    {
+ *     "name": "John Doe",
+ *     "email": "example@example.com",
+ *     "message": "Hi, I was wondering if you could help me... "
+ *    }
  */
 export async function handleContactPost(request: Request, response: Response) {
     const { name, email, message } = request.body as IContactRequest;
 
     await sendContactUsEmail(name, email, message);
-
-    return response.json();
+    return response.send();
 }

--- a/app/controllers/contact.controller.ts
+++ b/app/controllers/contact.controller.ts
@@ -1,0 +1,17 @@
+import { NextFunction, Request, Response } from 'express';
+import { IContactRequest } from '../request/IRequest';
+import { sendContactUsEmail } from '../services/Mail.service';
+
+/**
+ * @api {post} /contact Endpoint for contact us forms to be posted too.
+ * @apiVersion 1.0.0
+ * @apiName ContactUs
+ * @apiGroup Contact
+ */
+export async function handleContactPost(request: Request, response: Response) {
+    const { name, email, message } = request.body as IContactRequest;
+
+    await sendContactUsEmail(name, email, message);
+
+    return response.json();
+}

--- a/app/mail/contact-us.mjml
+++ b/app/mail/contact-us.mjml
@@ -1,0 +1,26 @@
+<mjml>
+  <mj-body background-color="#090b11">
+    <mj-include path="./layouts/header.mjml"></mj-include>
+
+    <mj-section>
+      <mj-column>
+        <mj-text font-weight="bold" align="center" font-size="24px" color="#fff" font-family="helvetica">DevWars Contact Us!</mj-text>
+        <mj-text align="center" line-height="160%" font-size="16px" color="#fff" font-family="helvetica">
+          Thank you for contacting us <strong>__NAME__</strong>! We received your email, you will
+          hear back from us soon. Below is a copy of the contact-us response that was sent.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding-top="0">
+      <mj-column>
+        <mj-text align="left" font-size="16px" color="#fff" font-family="helvetica">Name: __NAME__</mj-text>
+        <mj-text align="left" font-size="16px" color="#fff" font-family="helvetica">Email: __EMAIL__</mj-text>
+        <mj-text align="left" line-height="160%" font-size="16px" color="#fff" font-family="helvetica">
+          __MESSAGE__
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-include path="./layouts/simple-footer.mjml"></mj-include>
+  </mj-body>
+</mjml>

--- a/app/mail/layouts/footer.mjml
+++ b/app/mail/layouts/footer.mjml
@@ -1,28 +1,6 @@
 <mjml>
   <mj-body>
-    <mj-wrapper>
-      <mj-section padding="0px 0px 20px" background-color="#0B0C11">
-        <mj-column>
-          <mj-text align="center" color="#c9d0df" font-size="13px">
-            <p>
-              &copy; 2019 All Rights Reserved.
-            </p>
-            <a href="#" style="color: #c9d0df">Unsubscribe</a>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <mj-section background-color="#0B0C11">
-        <mj-column width="100%">
-          <mj-social>
-            <mj-social-element name="facebook-noshare" href="https://www.facebook.com/DevWars/"></mj-social-element>
-            <mj-social-element name="twitter-noshare" href="https://www.twitter.com/devwarstv"></mj-social-element>
-          </mj-social>
-        </mj-column>
-        <mj-column width="100%">
-          <mj-text align="center" color="#c9d0df" text-transform="uppercase">&copy; <a style="text-decoration: none; color: inherit;" href="https://www.devwars.tv/">DEVWARS.TV</a> - 2019</mj-text>
-          <mj-text align="center" color="#c9d0df"><a style="text-decoration: none; color: inherit;" href="https://discord.gg/devwars">Join our Discord!</a></mj-text>
-        </mj-column>
-      </mj-section>
-    </mj-wrapper>
+    <mj-include path="./simple-footer.mjml"></mj-include>
+    <mj-include path="./unsubscribe.mjml"></mj-include>
   </mj-body>
 </mjml>

--- a/app/mail/layouts/simple-footer.mjml
+++ b/app/mail/layouts/simple-footer.mjml
@@ -1,0 +1,16 @@
+<mjml>
+  <mj-body>
+    <mj-section background-color="#0B0C11">
+      <mj-column width="100%">
+        <mj-social>
+          <mj-social-element name="facebook-noshare" href="https://www.facebook.com/DevWars/"></mj-social-element>
+          <mj-social-element name="twitter-noshare" href="https://www.twitter.com/devwarstv"></mj-social-element>
+        </mj-social>
+      </mj-column>
+      <mj-column width="100%">
+        <mj-text align="center" color="#c9d0df" text-transform="uppercase">&copy; <a style="text-decoration: none; color: inherit;" href="https://www.devwars.tv/">DEVWARS.TV</a> - 2019</mj-text>
+        <mj-text align="center" color="#c9d0df"><a style="text-decoration: none; color: inherit;" href="https://discord.gg/devwars">Join our Discord!</a></mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/app/mail/layouts/unsubscribe.mjml
+++ b/app/mail/layouts/unsubscribe.mjml
@@ -1,0 +1,15 @@
+<mjml>
+  <mj-body>
+    <mj-wrapper>
+      <mj-section padding="0px 0px 20px" background-color="#0B0C11">
+        <mj-column>
+          <mj-text align="center" color="#c9d0df" font-size="13px">
+            <p>
+              &copy; 2019 All Rights Reserved.
+            </p>
+            <a href="#" style="color: #c9d0df">Unsubscribe</a>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+  </mj-body>
+</mjml>

--- a/app/request/IRequest.ts
+++ b/app/request/IRequest.ts
@@ -36,3 +36,13 @@ export interface IScheduleRequest extends Request {
 export interface IGameRequest extends Request {
     game: Game;
 }
+
+/**
+ * Extends the default express request to contain a localized object of the DevWars contact us request, this will
+ * include the name, email and message the user is sending with the contact us page.
+ */
+export interface IContactRequest extends Request {
+    name: string;
+    email: string;
+    message: string;
+}

--- a/app/routes/contact.routes.ts
+++ b/app/routes/contact.routes.ts
@@ -1,0 +1,12 @@
+import * as express from 'express';
+
+import { asyncErrorHandler } from './handlers';
+import * as contactController from '../controllers/contact.controller';
+import { contactUsSchema } from './validators/contact.validator';
+import { bodyValidation } from './validators';
+
+const ContactRoute: express.Router = express.Router();
+
+ContactRoute.post('/', [bodyValidation(contactUsSchema)], asyncErrorHandler(contactController.handleContactPost));
+
+export { ContactRoute };

--- a/app/routes/index.ts
+++ b/app/routes/index.ts
@@ -9,6 +9,7 @@ import { LeaderboardRoute } from './Leaderboard.route';
 import { LinkedAccountRoute } from './LinkedAccount.routes';
 import { UserRoute } from './User.routes';
 import { TempRoute } from './Temp.routes';
+import { ContactRoute } from './contact.routes';
 
 interface IRoute {
     path: string;
@@ -61,6 +62,11 @@ export const Routes: IRoute[] = [
         handler: UserRoute,
         middleware: [],
         path: '/users',
+    },
+    {
+        handler: ContactRoute,
+        middleware: [],
+        path: '/contact',
     },
 
     // TEMP: To support cookie authentication for Old Editor

--- a/app/routes/validators/contact.validator.ts
+++ b/app/routes/validators/contact.validator.ts
@@ -1,0 +1,23 @@
+import * as Joi from '@hapi/joi';
+import {
+    CONTACT_US_NAME_MIN,
+    CONTACT_US_NAME_MAX,
+    CONTACT_US_MESSAGE_MIN,
+    CONTACT_US_MESSAGE_MAX,
+} from '../../constants';
+
+export const contactUsSchema = Joi.object().keys({
+    name: Joi.string()
+        .min(CONTACT_US_NAME_MIN)
+        .max(CONTACT_US_NAME_MAX)
+        .required(),
+
+    email: Joi.string()
+        .email()
+        .required(),
+
+    message: Joi.string()
+        .min(CONTACT_US_MESSAGE_MIN)
+        .max(CONTACT_US_MESSAGE_MAX)
+        .required(),
+});

--- a/app/services/Mail.service.ts
+++ b/app/services/Mail.service.ts
@@ -83,3 +83,20 @@ export async function sendPasswordResetEmail(user: User, resetUrl: string) {
 
     await send(user.email, subject, output.html);
 }
+
+export async function sendContactUsEmail(name: string, email: string, message: string) {
+    const subject = `DevWars Contact Us - ${name}`;
+
+    const filePath = path.resolve(__dirname, '../mail/contact-us.mjml');
+    const template = fs.readFileSync(filePath).toString();
+    const output = mjml2html(template, { ...mjmlOptions, filePath });
+
+    // prettier-ignore
+    output.html = output.html
+        .replace(/__NAME__/g, name)
+        .replace(/__EMAIL__/g, email)
+        .replace(/__MESSAGE__/g, message);
+
+    await send('contact@devwars.tv', subject, output.html);
+    await send(email, subject, output.html);
+}

--- a/test/contact.test.ts
+++ b/test/contact.test.ts
@@ -1,0 +1,115 @@
+import * as chai from 'chai';
+import * as supertest from 'supertest';
+
+import { Connection } from '../app/services/Connection.service';
+import ServerService from '../app/services/Server.service';
+import {
+    CONTACT_US_NAME_MAX,
+    CONTACT_US_NAME_MIN,
+    CONTACT_US_MESSAGE_MIN,
+    CONTACT_US_MESSAGE_MAX,
+} from '../app/constants';
+
+const server: ServerService = new ServerService();
+let agent: any;
+
+describe('Contact Us ', () => {
+    const validPost = {
+        name: 'John Doe',
+        email: 'example@example.com',
+        message: 'This is a test message that is valid.',
+    };
+
+    before(async () => {
+        await server.Start();
+        await (await Connection).synchronize(true);
+    });
+
+    beforeEach(() => {
+        agent = supertest.agent(server.App());
+    });
+
+    describe('POST /contact - Creating a new contact us request.', () => {
+        it('Should pass if name, email and message are valid', async () => {
+            await agent
+                .post('/contact')
+                .send(validPost)
+                .expect(200);
+        });
+
+        it('Should fail if no name, email or message is provided', async () => {
+            const { name, email, message } = { ...validPost };
+
+            for (const test of [{ email, message }, { name, message }, { name, email }, {}]) {
+                await agent
+                    .post('/contact')
+                    .send(test)
+                    .expect(400);
+            }
+        });
+
+        it('Should fail the name is above or below the constraints', async () => {
+            let name = '';
+            while (name.length < CONTACT_US_NAME_MIN - 1) name += 'A';
+
+            await agent
+                .post('/contact')
+                .send({ name, email: validPost.email, message: validPost.message })
+                .expect(400, {
+                    error: 'name length must be at least 3 characters long, please check your content and try again',
+                });
+
+            while (name.length < CONTACT_US_NAME_MAX + 1) name += 'A';
+
+            await agent
+                .post('/contact')
+                .send({ name, email: validPost.email, message: validPost.message })
+                .expect(400, {
+                    error:
+                        'name length must be less than or equal to 64 characters long, please check your content and try again',
+                });
+        });
+
+        it('Should fail the email is not a valid email.', async () => {
+            const { name, message } = { ...validPost };
+
+            const invalidEmail = 'email must be a valid email, please check your content and try again';
+            const emptyEmail = 'email is not allowed to be empty, please check your content and try again';
+
+            for (const email of ['test.com', 'testing', '@test.com']) {
+                await agent
+                    .post('/contact')
+                    .send({ name, email, message })
+                    .expect(400, { error: invalidEmail });
+            }
+
+            await agent
+                .post('/contact')
+                .send({ name, email: '', message })
+                .expect(400, { error: emptyEmail });
+        });
+
+        it('Should fail the message is above or below the constraints', async () => {
+            let message = '';
+            while (message.length < CONTACT_US_MESSAGE_MIN - 1) message += 'A';
+
+            await agent
+                .post('/contact')
+                .send({ name: validPost.name, email: validPost.email, message })
+                .expect(400, {
+                    error:
+                        'message length must be at least 24 characters long, please check your content and try again',
+                });
+
+            while (message.length < CONTACT_US_MESSAGE_MAX + 1) message += 'A';
+
+            await agent
+                .post('/contact')
+                .send({ message, email: validPost.email, name: validPost.name })
+                .expect(400, {
+                    error:
+                        'message length must be less than or equal to 500 characters long, please check your content and try again',
+                });
+        });
+    });
+});


### PR DESCRIPTION
### Overview
Support for contact-us is now back, allowing the api to accept posts to the api at /contact. The endpoint will ensure that name, email and message are provided and they meet the constraint requirements. When a contact us email comes in, a email response will be sent to the contact@devwars + the user with information about the response.

 * This lead to the footer and unsubscribe being broken up to support not enforcing the unsubscribe within emails that don't need it (e.g contact us).
 * this is inline with some website changes to ensure smoother usage of the contact-us page. (https://github.com/DevWars/devwars.tv/pull/19)

#### Example of a contact-us response (sent to both the sender and devwars).
![image](https://user-images.githubusercontent.com/12329422/71416696-8267b180-2659-11ea-9923-9a3ec9ed6969.png)

#### Documentation
![image](https://user-images.githubusercontent.com/12329422/71416702-88f62900-2659-11ea-9c57-d0c3db1a7b45.png)
