### PR TITLE
Fix/resigning and discord disconnect

### DIFF
--- a/app/controllers/game/GameApplication.controller.ts
+++ b/app/controllers/game/GameApplication.controller.ts
@@ -149,18 +149,21 @@ export async function resignFromSchedule(request: IRequest & IScheduleRequest, r
     const gameApplicationRepository = getCustomRepository(GameApplicationRepository);
 
     const application = await gameApplicationRepository.findByUserAndSchedule(request.user, request.schedule);
+    const { id: applicationId } = application;
 
     if (_.isNil(application)) {
-        const error = `No game application exists for schedule ${request.schedule.id} by user ${request.user.username}`;
+        const { username } = request.user;
+        const { id } = request.schedule;
+
         return response.status(404).json({
-            error,
+            error: `No game application exists for schedule ${id} by user ${username}`,
         });
     }
 
-    await gameApplicationRepository.delete(application);
-
+    await application.remove();
     await SendGameApplicationResignEmail(application);
-    return response.send();
+
+    return response.send({ application: applicationId });
 }
 
 /**

--- a/app/controllers/user/LinkedAccount.controller.ts
+++ b/app/controllers/user/LinkedAccount.controller.ts
@@ -12,7 +12,7 @@ import { IRequest, IUserRequest } from '../../request/IRequest';
 import { parseIntWithDefault } from '../../../test/helpers';
 
 /**
- * @api {get} /oauth?limit={:limit}&offset={:offset}
+ * @api {get} /oauth?limit={:limit}&offset={:offset} Gather all linked accounts within the constraints.
  * @apiDescription Gather all linked accounts that are organize by updatedAt. With limit and offset
  * specification to page the content.
  *
@@ -20,8 +20,8 @@ import { parseIntWithDefault } from '../../../test/helpers';
  * @apiGroup LinkedAccounts
  * @apiPermission moderator
  *
- * @apiParam {string} limit The number of linked accounts to gather from the offset (limit: 100)
- * @apiParam {string} offset The offset of which place to start gathering linked accounts from  (limit: 100)
+ * @apiParam {string} limit The number of linked accounts to gather from the offset (limit: 100).
+ * @apiParam {string} offset The offset of which place to start gathering linked accounts from.
  *
  * @apiSuccess {json} LinkedAccounts The linked accounts within the limit and offset.
  *
@@ -92,7 +92,7 @@ export async function disconnect(request: IRequest, response: Response) {
 
     await linkedAccount.remove();
 
-    await SendUnLinkedAccountEmail(linkedAccount);
+    await SendUnLinkedAccountEmail(request.user, provider);
     return response.json(linkedAccount);
 }
 
@@ -139,12 +139,12 @@ async function connectDiscord(request: Request, response: Response, user: User) 
 
     await linkedAccount.save();
 
-    await SendLinkedAccountEmail(linkedAccount);
+    await SendLinkedAccountEmail(user, Provider.DISCORD);
     return response.redirect(`${process.env.FRONT_URL}/settings/connections`);
 }
 
 /**
- * @api {get} /:user/connections Request All users linked accounts.
+ * @api {get} /:user/connections Request all users linked accounts.
  * @apiName GetUsersConnections
  * @apiGroup User
  * @apiPermission owner/moderator
@@ -171,7 +171,7 @@ export async function gatherAllUserConnections(request: IUserRequest, response: 
 }
 
 /**
- * @api {get} /:user/connections Request All users linked accounts by provider.
+ * @api {get} /:user/connections/:provider Request all users linked accounts by provider.
  * @apiName GetUsersConnectionsByProvider
  * @apiGroup User
  * @apiPermission owner/moderator

--- a/app/controllers/user/User.controller.ts
+++ b/app/controllers/user/User.controller.ts
@@ -102,8 +102,8 @@ export async function show(request: IUserRequest, response: Response) {
  * @apiGroup User
  * @apiPermission moderator
  *
- * @apiParam {string} limit The number of linked accounts to gather from the offset (limit: 100)
- * @apiParam {string} offset The offset of which place to start gathering linked accounts from  (limit: 100)
+ * @apiParam {string} limit The number of users to gather from the offset. (limit: 100)
+ * @apiParam {string} offset The offset of which place to start gathering users from.
  *
  * @apiSuccess {json} Users The users within the limit and offset.
  *

--- a/app/controllers/user/User.controller.ts
+++ b/app/controllers/user/User.controller.ts
@@ -2,12 +2,13 @@ import { getCustomRepository } from 'typeorm';
 import { Request, Response } from 'express';
 import { isNil, isInteger } from 'lodash';
 
-import User from '../../models/User';
-import { UserRole } from '../../models/User';
 import UserRepository from '../../repository/User.repository';
-import { IRequest, IUserRequest } from '../../request/IRequest';
+import { IUserRequest } from '../../request/IRequest';
 import { hash } from '../../utils/hash';
-import { stringify } from 'querystring';
+
+import { parseIntWithDefault } from '../../../test/helpers';
+import { UserRole } from '../../models/User';
+import User from '../../models/User';
 
 interface IUpdateUserRequest {
     lastSigned: Date;
@@ -99,7 +100,12 @@ export async function show(request: IUserRequest, response: Response) {
  * @api {get} /:user Request All User basic information
  * @apiName GetUsers
  * @apiGroup User
- * @apiPermission administrator
+ * @apiPermission moderator
+ *
+ * @apiParam {string} limit The number of linked accounts to gather from the offset (limit: 100)
+ * @apiParam {string} offset The offset of which place to start gathering linked accounts from  (limit: 100)
+ *
+ * @apiSuccess {json} Users The users within the limit and offset.
  *
  * @apiSuccessExample Success-Response:
  *     HTTP/1.1 200 OK
@@ -124,7 +130,15 @@ export async function show(request: IUserRequest, response: Response) {
  *     }]
  */
 export async function all(request: Request, response: Response) {
-    const users = await User.find();
+    const limit = parseIntWithDefault(request.query.limit, 25, 1, 100);
+    const offset = parseIntWithDefault(request.query.offset, 0, 0);
+
+    const users = await User.createQueryBuilder('user')
+        .orderBy('"updatedAt"', 'DESC')
+        .limit(limit > 100 || limit < 1 ? 100 : limit)
+        .offset(offset < 0 ? 0 : offset)
+        .getMany();
+
     return response.json(users);
 }
 

--- a/app/repository/EmailOptIn.repository.ts
+++ b/app/repository/EmailOptIn.repository.ts
@@ -11,7 +11,6 @@ export default class EmailOptInRepository extends Repository<EmailOptIn> {
      * @param user The user who's permissions are being gathered.
      */
     public async getEmailOptInPermissionForUser(user: User): Promise<EmailOptIn> {
-        if (_.isNil(user)) return null;
-        return await EmailOptIn.findOne({ where: { user: user.id } });
+        return await EmailOptIn.findOne({ where: { user } });
     }
 }

--- a/app/repository/GameApplication.repository.ts
+++ b/app/repository/GameApplication.repository.ts
@@ -10,7 +10,7 @@ export default class GameApplicationRepository extends Repository<GameApplicatio
         return GameApplication.find({ where: { user }, relations: ['schedule'] });
     }
 
-    public findByUserAndSchedule(user: User, schedule: GameSchedule) {
+    public findByUserAndSchedule(user: User, schedule: GameSchedule): Promise<GameApplication> {
         return GameApplication.findOne({ where: { user, schedule }, relations: ['schedule', 'user'] });
     }
 }

--- a/app/repository/LinkedAccount.repository.ts
+++ b/app/repository/LinkedAccount.repository.ts
@@ -4,12 +4,12 @@ import User from '../models/User';
 
 @EntityRepository(User)
 export default class LinkedAccountRepository extends Repository<LinkedAccount> {
-    public findAllByUserId(userId: number): Promise<LinkedAccount[]> {
-        return LinkedAccount.find({ where: { user: userId }, relations: ['user'] });
+    public findAllByUserId(userId: number, relations?: string[]): Promise<LinkedAccount[]> {
+        return LinkedAccount.find({ where: { user: userId }, relations });
     }
 
-    public findByUserIdAndProvider(userId: number, provider: string): Promise<LinkedAccount> {
-        return LinkedAccount.findOne({ where: { user: userId, provider }, relations: ['user'] });
+    public findByUserIdAndProvider(userId: number, provider: string, relations?: string[]): Promise<LinkedAccount> {
+        return LinkedAccount.findOne({ where: { user: userId, provider: provider.toUpperCase() }, relations });
     }
 
     public findByProviderAndProviderId(provider: string, providerId: string): Promise<LinkedAccount> {
@@ -17,11 +17,13 @@ export default class LinkedAccountRepository extends Repository<LinkedAccount> {
     }
 
     public async createMissingAccounts(twitchUsers: any[], provider: Provider): Promise<LinkedAccount[]> {
-        const userIds = twitchUsers.map(user => user.id);
+        const userIds = twitchUsers.map((user) => user.id);
         const existingAccounts = await LinkedAccount.find({ providerId: In(userIds) });
 
-        const newUsers = twitchUsers.filter(user => !existingAccounts.find(account => account.providerId === user.id));
-        const newAccounts = newUsers.map(user => new LinkedAccount(null, user.username, provider, user.id));
+        const newUsers = twitchUsers.filter(
+            (user) => !existingAccounts.find((account) => account.providerId === user.id)
+        );
+        const newAccounts = newUsers.map((user) => new LinkedAccount(null, user.username, provider, user.id));
 
         return LinkedAccount.save(newAccounts);
     }

--- a/app/routes/LinkedAccount.routes.ts
+++ b/app/routes/LinkedAccount.routes.ts
@@ -10,7 +10,12 @@ import { updateTwitchCoinsSchema } from './validators/linkedAccount.validator';
 
 const LinkedAccountRoute: express.Router = express.Router();
 
-LinkedAccountRoute.get('/', mustBeAuthenticated, asyncErrorHandler(LinkedAccountController.all));
+LinkedAccountRoute.get(
+    '/',
+    [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)],
+    asyncErrorHandler(LinkedAccountController.all)
+);
+
 LinkedAccountRoute.get('/:provider', mustBeAuthenticated, asyncErrorHandler(LinkedAccountController.connect));
 LinkedAccountRoute.delete('/:provider', mustBeAuthenticated, asyncErrorHandler(LinkedAccountController.disconnect));
 

--- a/app/routes/User.routes.ts
+++ b/app/routes/User.routes.ts
@@ -5,6 +5,7 @@ import * as UserController from '../controllers/user/User.controller';
 import * as UserProfileController from '../controllers/user/UserProfile.controller';
 import * as UserStatsController from '../controllers/user/UserStats.controller';
 import * as UserGameStatsController from '../controllers/user/UserGameStats.controller';
+import * as LinkedAccountController from '../controllers/user/LinkedAccount.controller';
 import * as UserAvatarController from '../controllers/user/UserAvatar.controller';
 import * as EmailController from '../controllers/Email.controller';
 
@@ -23,7 +24,7 @@ const UserRoute: express.Router = express.Router();
  *  GENERAL
  ******************************/
 
-UserRoute.get('/', [mustBeAuthenticated, mustBeRole(UserRole.ADMIN)], asyncErrorHandler(UserController.all));
+UserRoute.get('/', [mustBeAuthenticated, mustBeRole(UserRole.MODERATOR)], asyncErrorHandler(UserController.all));
 
 UserRoute.get(
     '/lookup',
@@ -99,6 +100,21 @@ UserRoute.patch(
         bodyValidation(emailPermissionSchema),
     ],
     asyncErrorHandler(EmailController.updateEmailPermissions)
+);
+
+/******************************
+ *  Linked Accounts
+ ******************************/
+
+UserRoute.get(
+    '/:user/connections',
+    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.MODERATOR), bindUserFromUserParam],
+    asyncErrorHandler(LinkedAccountController.gatherAllUserConnections)
+);
+UserRoute.get(
+    '/:user/connections/:provider',
+    [mustBeAuthenticated, mustBeRoleOrOwner(UserRole.MODERATOR), bindUserFromUserParam],
+    asyncErrorHandler(LinkedAccountController.gatherAllUserConnectionsByProvider)
 );
 
 export { UserRoute };

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,8 +1,11 @@
 {
     "watch": ["**/*.ts"],
     "ext": "ts",
-    "ignore": ["./test/*.ts"],
+    "ignore": ["*.test.ts"],
     "exec": "node --inspect -r ts-node/register ./app/index.ts",
+    "sourceMaps": true,
+    "cwd": "${workspaceRoot}",
+    "protocol": "inspector",
     "env": {
         "NODE_ENV": "development"
     }

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-    "watch": ["**/*.ts"],
+    "watch": ["**/*.ts", ".env"],
     "ext": "ts",
     "ignore": ["*.test.ts"],
     "exec": "node --inspect -r ts-node/register ./app/index.ts",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,30 @@
 import User from '../app/models/User';
 import { AuthService } from '../app/services/Auth.service';
+import { isNumber, isNil } from 'lodash';
 
 export const cookieForUser = async (user: User): Promise<string> => {
     return `token=${await AuthService.newToken(user)}`;
+};
+
+/**
+ * Takes in a possible int value, ensures its a number and within a given bound. Returning the
+ * parsed number if so otherwise the fallback default value (default: 0). Used during the parsing of
+ * possible numerical values within a query.
+ *
+ * @param possible The possible value to be parsed.
+ * @param def The fallback default value.
+ * @param lower The lower bounds of the value.
+ * @param upper The upper bounds of the value.
+ */
+export const parseIntWithDefault = (possible: any, def: number = 0, lower?: number, upper?: number): number => {
+    if (isNil(possible) || !isNumber(Number(possible))) {
+        return def;
+    }
+
+    const result = Number(possible);
+
+    if (!isNil(lower) && result < lower) return def;
+    if (!isNil(upper) && result > upper) return def;
+
+    return result;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es2018",
-        "lib": ["es2018", "dom"],
+        "lib": ["es2018"],
         "noImplicitAny": true,
         "sourceMap": true,
         "emitDecoratorMetadata": true,


### PR DESCRIPTION
### Overview
This pull request is to solve problems that raised related to account connections and resigning from existing game applications. 

#### Resigning
When a user resigns, the application now correctly deletes its related information. It was caused by not using the correct database connection and the change not taking place. With the addition of the emails no longer requiring the linked account object since it could not exist when the email is being sent.

#### Disconnecting Discord
The problem was that disconnection was working but linked account status was determined by the /oauth endpoint. This endpoint was returning ALL related connections and just checking if a discord one exists. If it did exist, you 'had' a connection.

This is fixed by introducing two new endpoints `/users/:userId/connections` and `/users/:userId/connections/:provider`. This will be used as the owner or moderator to gather the specified user's connections or connections by a provider. ([changes required to the front end here](https://github.com/DevWars/devwars.tv/pull/25)).

![image](https://user-images.githubusercontent.com/12329422/71930549-cdbeab80-3193-11ea-8a4c-5f766c7c71cd.png)

![image](https://user-images.githubusercontent.com/12329422/71930533-c5667080-3193-11ea-9976-d8a6304eea99.png)

Both endpoints for gathering all users and all connections are now paged based (limits and offsets) which require moderation or higher permissions.

![image](https://user-images.githubusercontent.com/12329422/71930788-47569980-3194-11ea-81cb-d8a9f583e723.png)

![image](https://user-images.githubusercontent.com/12329422/71930865-710fc080-3194-11ea-91cd-4f8cd30010d3.png)

### Notes
 * nodemon will now reload when the .env changes.
 * related to the front-end changes [here](https://github.com/DevWars/devwars.tv/pull/25).

### Related issues
#33 