### PR TITLE
Game endpoint now supports specifying the inclusion of player data.

### DIFF
--- a/app/middleware/GameApplication.middleware.ts
+++ b/app/middleware/GameApplication.middleware.ts
@@ -7,6 +7,7 @@ import GameRepository from '../repository/Game.repository';
 import { DATABASE_MAX_ID } from '../constants';
 import { wrapAsync } from '../routes/handlers';
 import ApiError from '../utils/apiError';
+import { parseIntWithDefault, parseBooleanWithDefault } from '../../test/helpers';
 
 /**
  * Ensures that the requesting authorized user has provided a valid schedule id, this id will be validated,
@@ -15,10 +16,9 @@ import ApiError from '../utils/apiError';
  */
 export const bindGameFromGameParam = wrapAsync(
     async (request: IGameRequest, response: Response, next: NextFunction) => {
-        const { game: gameId } = request.params;
+        const gameId = parseIntWithDefault(request.params.game, null, 1, DATABASE_MAX_ID);
 
-        if (_.isNil(gameId) || isNaN(_.toNumber(gameId)) || Number(gameId) > DATABASE_MAX_ID)
-            throw new ApiError({ code: 400, error: 'Invalid game id provided.' });
+        if (_.isNil(gameId)) throw new ApiError({ code: 400, error: 'Invalid game id provided.' });
 
         const gameRepository = getCustomRepository(GameRepository);
         const game = await gameRepository.findOne(gameId, { relations: ['schedule'] });

--- a/app/models/UserProfile.ts
+++ b/app/models/UserProfile.ts
@@ -3,9 +3,9 @@ import BaseModel from './BaseModel';
 import User from './User';
 
 export enum Sex {
-    MALE,
-    FEMALE,
-    OTHER,
+    MALE = 0,
+    FEMALE = 1,
+    OTHER = 2,
 }
 
 @Entity('user_profile')

--- a/app/routes/validators/user.validator.ts
+++ b/app/routes/validators/user.validator.ts
@@ -28,55 +28,57 @@ export const statsSchema = Joi.object()
 export const profileSchema = Joi.object()
     .keys({
         firstName: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         lastName: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
-        dob: Joi.date().optional(),
+        dob: Joi.date()
+            .allow(null)
+            .optional(),
 
         sex: Joi.string()
-            .valid(...Object.values(Sex))
+            .valid(Sex.MALE, Sex.FEMALE, Sex.OTHER)
             .optional(),
 
         about: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         forHire: Joi.boolean().optional(),
 
         company: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         websiteUrl: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         addressOne: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         addressTwo: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         city: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         state: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         zip: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         country: Joi.string()
-            .allow('')
+            .allow('', null)
             .optional(),
 
         skills: Joi.object().optional(),

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,5 +1,5 @@
-import { isNumber, isNil } from 'lodash';
 import * as fs from 'fs';
+import { isNumber, isNil, isBoolean } from 'lodash';
 
 import { AuthService } from '../app/services/Auth.service';
 import User from '../app/models/User';
@@ -29,6 +29,21 @@ export const parseIntWithDefault = (possible: any, def: number = 0, lower?: numb
     if (!isNil(upper) && result > upper) return def;
 
     return result;
+};
+
+/**
+ * Parses any given object and attempts to form a boolean value. This includes 1,0 (number and strings),
+ * @param possible The possible value to be parsed.
+ * @param def The default value ot be returned otherwise if not a boolean.
+ */
+export const parseBooleanWithDefault = (possible: any, def: boolean = false): boolean => {
+    if (isNil(possible)) return def;
+
+    if (possible === 1 || possible === 0) return Boolean(possible);
+    if (possible === '0' || possible === '1') return possible === '1';
+    if (possible === 'true' || possible === 'false') return possible === 'true';
+
+    return !isBoolean(possible) ? def : Boolean(possible);
 };
 
 /**


### PR DESCRIPTION
### Overview 📚
You can now specify if you want to include complete user information for the players when gathering the game. By default no player information will be gathered. Only the already existing id, team and username will be returned.

When updating profiles, null values are now allowed which is the default value within the database. Also the sex is now clearly defined as integers within the enum and the schema. Ensuring not to allow string based sex as a input for profile update.

If strings are allowed, when they insert into the database, it causes a
query error that 500's.

### Notes 📝

* Boolean parser now included within the helper, used to process query booleans with a deafult value if parse could not be determined.
 * test cases for gathering with and without the players complete details.
 *  bindGameFromParam uses helper method over raw checks.

### Related Pull Requests 📢
* https://github.com/DevWars/devwars.tv/pull/37