### PR TITLE
feat: support for applying to games via a Twitch id

### DIFF
--- a/app/controllers/game/Game.controller.ts
+++ b/app/controllers/game/Game.controller.ts
@@ -26,6 +26,7 @@ export function flattenGame(game: Game) {
         mode: game.mode,
         videoUrl: game.videoUrl,
         status: game.status, // TEMPORARY
+        schedule: game.schedule?.id || null,
     };
 }
 
@@ -90,7 +91,7 @@ export async function latest(request: Request, response: Response) {
 
 export async function active(request: Request, response: Response) {
     const gameRepository = getCustomRepository(GameRepository);
-    const game = await gameRepository.active();
+    const game = await gameRepository.active(['schedule']);
 
     if (_.isNil(game)) {
         throw new ApiError({

--- a/app/controllers/game/GameApplication.controller.ts
+++ b/app/controllers/game/GameApplication.controller.ts
@@ -202,7 +202,7 @@ export async function applyToScheduleFromTwitch(request: IScheduleRequest, respo
     const linkedAccountRepository = getCustomRepository(LinkedAccountRepository);
     const linkedAccount = await linkedAccountRepository.findByProviderAndProviderId(Provider.TWITCH, TwitchId);
 
-    if (_.isNil(linkedAccount)) {
+    if (_.isNil(linkedAccount) || _.isNil(linkedAccount.user)) {
         throw new ApiError({
             message: 'No user exists with the a linked account to twitch with the specified id.',
             code: 400,

--- a/app/controllers/game/GameApplication.controller.ts
+++ b/app/controllers/game/GameApplication.controller.ts
@@ -6,12 +6,15 @@ import { IGameRequest, IRequest, IScheduleRequest } from '../../request/IRequest
 import { sendGameApplicationApplyingEmail, SendGameApplicationResignEmail } from '../../services/Mail.service';
 
 import GameApplicationRepository from '../../repository/GameApplication.repository';
-import GameScheduleRepository from '../../repository/GameSchedule.repository';
 import UserRepository from '../../repository/User.repository';
 
+import { parseStringWithDefault } from '../../../test/helpers';
 import GameApplication from '../../models/GameApplication';
-import User, { UserRole } from '../../models/User';
+import User from '../../models/User';
 import ApiError from '../../utils/apiError';
+import { DATABASE_MAX_ID } from '../../constants';
+import LinkedAccountRepository from '../../repository/LinkedAccount.repository';
+import { Provider } from '../../models/LinkedAccount';
 
 /**
  * @api {get} /mine Returns a list of game applications currently registered on.
@@ -121,10 +124,102 @@ export async function getCurrentUserGameApplications(request: IRequest, response
  * }
  *
  * @apiError ScheduleIdNotDefined Invalid schedule id provided.
- * @apiError GameScheduleDoesNotExist A game schedule does not exist by the provided game id.
+ * @apiError GameScheduleDoesNotExist A game schedule does not exist by the provided game id. export
+ * @apiError GameApplicationAlreadyExists A game application already exists for user for schedule.
  */
 export async function applyToSchedule(request: IRequest & IScheduleRequest, response: Response) {
+    const gameApplicationRepository = getCustomRepository(GameApplicationRepository);
+    const exists = await gameApplicationRepository.findByUserAndSchedule(request.user, request.schedule);
+
+    if (!_.isNil(exists)) {
+        throw new ApiError({
+            message: 'A game application already exists for user for schedule.',
+            code: 409,
+        });
+    }
+
     const application = new GameApplication(request.schedule, request.user);
+    await application.save();
+
+    await sendGameApplicationApplyingEmail(application);
+    return response.json(application);
+}
+
+/**
+ * @api {post} /applications/schedule/:scheduleId/twitch?twitch_id= Applies the twitch user to the scheduled game.
+ * @apiDescription Applies the twitch user to the given schedule by creating a game application. The
+ * game application is return to the applying user. Containing the schedule and user. The
+ * specified twitch id must link to a DevWars user for this to work.
+ * @apiVersion 1.0.0
+ * @apiName GameApplicationApplyByScheduleAndTwitchId
+ * @apiGroup Applications
+ *
+ * @apiParam {number} ScheduleId The id of the schedule being applied too.
+ * @apiParam {string} twitch_id The id of the twitch user applying.
+ *
+ * @apiSuccess {GameApplication} schedule The application of the game applied too.
+ * @apiSuccessExample Success-Response: HTTP/1.1 200 OK
+ * {
+ *   "schedule": {"id": 1, "updatedAt": "2019-10-04T16:10:24.334Z", "createdAt":
+ *     "2019-10-04T16:10:24.334Z", "startTime": "2020-03-20T03:37:46.716Z", "status": 2, "setup":
+ *     {"mode": "Classic", "title": "capacitor", "objectives": {"1": {"id": 1, "isBonus": false,
+ *     "description": "Id modi itaque quisquam non ea nam animi soluta maiores."
+ *         },
+ *         "2": {
+ *           "id": 2,
+ *           "isBonus": false,
+ *           "description": "Veritatis porro ducimus nam asperiores id."
+ *         },
+ *         "3": {
+ *           "id": 3,
+ *           "isBonus": false,
+ *           "description": "Nihil deleniti voluptatum ea."
+ *         },
+ *         "4": {
+ *           "id": 4,
+ *           "isBonus": true,
+ *           "description": "Atque fugiat cupiditate consequuntur repellendus ut."
+ *         }
+ *       }
+ *     }
+ *   },
+ *   "user": {"id": 3, "updatedAt": "2019-10-04T16:10:49.974Z", "createdAt":
+ *     "2019-10-04T16:10:21.748Z", "lastSignIn": "2019-10-04T16:10:49.969Z", "email":
+ *     "Thora32@yahoo.com", "username": "test-user", "role": "USER", "avatarUrl":
+ *     "http://lorempixel.com/640/480/city"
+ *   },
+ *   "id": 39, "updatedAt": "2019-10-04T16:40:01.906Z", "createdAt": "2019-10-04T16:40:01.906Z"
+ * }
+ *
+ * @apiError ScheduleIdNotDefined Invalid schedule id provided.
+ * @apiError GameScheduleDoesNotExist A game schedule does not exist by the provided game id. export
+ * @apiError GameApplicationAlreadyExists A game application already exists for user for schedule.
+ * @apiError TwitchLinkDoesNotExist No user exists with the a linked account to twitch with the specified id.
+ */
+export async function applyToScheduleFromTwitch(request: IScheduleRequest, response: Response) {
+    const TwitchId = parseStringWithDefault(request.query.twitch_id, null, 0, DATABASE_MAX_ID);
+
+    const linkedAccountRepository = getCustomRepository(LinkedAccountRepository);
+    const linkedAccount = await linkedAccountRepository.findByProviderAndProviderId(Provider.TWITCH, TwitchId);
+
+    if (_.isNil(linkedAccount)) {
+        throw new ApiError({
+            message: 'No user exists with the a linked account to twitch with the specified id.',
+            code: 400,
+        });
+    }
+
+    const gameApplicationRepository = getCustomRepository(GameApplicationRepository);
+    const exists = await gameApplicationRepository.findByUserAndSchedule(linkedAccount.user, request.schedule);
+
+    if (!_.isNil(exists)) {
+        throw new ApiError({
+            message: 'A game application already exists for user for schedule.',
+            code: 409,
+        });
+    }
+
+    const application = new GameApplication(request.schedule, linkedAccount.user);
     await application.save();
 
     await sendGameApplicationApplyingEmail(application);

--- a/app/repository/Game.repository.ts
+++ b/app/repository/Game.repository.ts
@@ -8,8 +8,8 @@ export default class GameRepository extends Repository<Game> {
         return this.findOne({ order: { createdAt: 'DESC' } });
     }
 
-    public active(): Promise<Game> {
-        return this.findOne({ where: { status: GameStatus.ACTIVE } });
+    public active(relations: string[]): Promise<Game> {
+        return this.findOne({ where: { status: GameStatus.ACTIVE }, relations });
     }
 
     public findAllBySeason(season: number): Promise<Game[]> {

--- a/app/routes/GameApplication.routes.ts
+++ b/app/routes/GameApplication.routes.ts
@@ -33,6 +33,12 @@ GameApplicationRoute.post(
     wrapAsync(GameApplicationController.applyToSchedule)
 );
 
+GameApplicationRoute.post(
+    '/schedule/:schedule/twitch',
+    [mustBeRole(UserRole.MODERATOR, true), bindScheduleFromScheduleParam],
+    wrapAsync(GameApplicationController.applyToScheduleFromTwitch)
+);
+
 GameApplicationRoute.delete(
     '/schedule/:schedule',
     [mustBeAuthenticated, bindScheduleFromScheduleParam],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "copy": "copyfiles ./firebase.json ./.env ./package.json ./**/*.mjml dist/",
         "clean": "rimraf dist",
         "lint": "tslint **/*.ts",
-        "serve-docs": "apidoc -i ./app -o ./docs && http-server docs",
+        "serve-docs": "apidoc -i ./app -o ./docs && http-server -p 8081 docs",
         "seed": "node -r ts-node/register ./cli/seeder.ts",
         "seed:password": "node -r ts-node/register ./cli/SeedPassword.ts",
         "typeorm": "ts-node -P ./tsconfig.json ./node_modules/.bin/typeorm",


### PR DESCRIPTION
When applying to a game schedule, a route exists for applying for a Twitch user. This user must have a linked twitch account on DevWars. Its a bot only authenticated route and will require prior knowledge of the schedule being applied too.

 * Support for ensuring that the game application does not already exist.
 * Moderators and above can also use the route.
 * http docs now serves on 8081 instead of 8080 to allow both api and docs to run at the same time.

### Bot Changes
**!apply** should determine the current users twitch Id, gather the current game schedule and post to: /applications/schedule/:scheduleId/twitch?twitch_id={twitchId} to apply the user.