### PR TITLE
fix: typo in run seed command that prevents seeding db

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "clean": "rimraf dist",
         "lint": "tslint **/*.ts",
         "serve-docs": "apidoc -i ./app -o ./docs && http-server -p 8081 docs",
-        "seed": "node -r ts-node/register ./cli/seeder.ts",
+        "seed": "node -r ts-node/register ./cli/Seeder.ts",
         "seed:password": "node -r ts-node/register ./cli/SeedPassword.ts",
         "typeorm": "ts-node-dev -P ./tsconfig.json ./node_modules/.bin/typeorm",
         "migrate": "ts-node-dev ./node_modules/.bin/typeorm migration:run",


### PR DESCRIPTION
Whilst following the setup given in README.md, I encountered this problem that prevented me from being able to seed the database
