### PR TITLE
Refactor: Increased control over database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ DB_PORT=5432
 DB_NAME=devwars
 DB_USER=postgres
 DB_PASS=postgres
+DB_LOGGING=false
+DB_SYNC=true
 
 # FIREBASE_URL (optional) - Use alongside the firebase service account
 # json file to connect and communicate with a firebase real-time database.
@@ -95,3 +97,7 @@ TEST_DB_PORT=5432
 TEST_DB_NAME=devwars_test
 TEST_DB_USER=postgres
 TEST_DB_PASS=postgres
+TEST_DB_LOGGING=false
+TEST_DB_SYNC=true
+
+

--- a/app/services/Connection.service.ts
+++ b/app/services/Connection.service.ts
@@ -2,14 +2,15 @@ import { config, DIALECT } from '../../config';
 import { Connection, createConnection } from 'typeorm';
 
 const connection: Promise<Connection> = createConnection({
-    entities: [__dirname + '/../models/*{.ts,js}'],
+    entities: [`${__dirname}/../models/*{.ts,js}`],
     type: DIALECT,
     database: config.DATABASE.NAME,
     host: config.DATABASE.HOST,
     port: Number(config.DATABASE.PORT),
     username: config.DATABASE.USER,
     password: config.DATABASE.PASS,
-    logging: false,
+    logging: config.DATABASE.LOGGING,
+    synchronize: config.DATABASE.SYNC,
 });
 
 export { connection as Connection };

--- a/config/index.ts
+++ b/config/index.ts
@@ -13,8 +13,8 @@ const TEST_CONFIGURATION = {
     NAME: process.env.TEST_DB_NAME,
     USER: process.env.TEST_DB_USER,
     PASS: process.env.TEST_DB_PASS,
-    SYNC: Boolean(defaultTo(process.env.TEST_DB_SYNC, true)),
-    LOGGING: Boolean(defaultTo(process.env.TEST_DB_LOGGING, false)),
+    SYNC: defaultTo(process.env.TEST_DB_SYNC, 'true') == 'true',
+    LOGGING: defaultTo(process.env.TEST_DB_LOGGING, 'false') == 'true',
 };
 
 const MASTER_CONFIGURATION = {
@@ -23,8 +23,8 @@ const MASTER_CONFIGURATION = {
     NAME: process.env.DB_NAME,
     USER: process.env.DB_USER,
     PASS: process.env.DB_PASS,
-    SYNC: Boolean(defaultTo(process.env.DB_SYNC, true)),
-    LOGGING: Boolean(defaultTo(process.env.DB_LOGGING, false)),
+    SYNC: defaultTo(process.env.DB_SYNC, 'true') === 'true',
+    LOGGING: defaultTo(process.env.DB_LOGGING, 'false') === 'true',
 };
 
 const config = {

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,11 +1,11 @@
 import * as dotenv from 'dotenv';
 import * as AWS from 'aws-sdk';
-import { isNil } from 'lodash';
+import { isNil, defaultTo } from 'lodash';
 
 dotenv.config();
 
-const DIALECT: any = process.env.DIALECT || 'postgres';
-const environment = process.env.NODE_ENV;
+const DIALECT: any = defaultTo(process.env.DIALECT, 'postgres');
+const environment = defaultTo(process.env.NODE_ENV, 'production');
 
 const TEST_CONFIGURATION = {
     HOST: process.env.TEST_DB_HOST,
@@ -13,6 +13,8 @@ const TEST_CONFIGURATION = {
     NAME: process.env.TEST_DB_NAME,
     USER: process.env.TEST_DB_USER,
     PASS: process.env.TEST_DB_PASS,
+    SYNC: Boolean(defaultTo(process.env.TEST_DB_SYNC, true)),
+    LOGGING: Boolean(defaultTo(process.env.TEST_DB_LOGGING, false)),
 };
 
 const MASTER_CONFIGURATION = {
@@ -21,6 +23,8 @@ const MASTER_CONFIGURATION = {
     NAME: process.env.DB_NAME,
     USER: process.env.DB_USER,
     PASS: process.env.DB_PASS,
+    SYNC: Boolean(defaultTo(process.env.DB_SYNC, true)),
+    LOGGING: Boolean(defaultTo(process.env.DB_LOGGING, false)),
 };
 
 const config = {


### PR DESCRIPTION
### Overview

The API .env file now supports direct configuration for database logging and synchronisation rules. This is to allow more finite control for the developer while also supporting the ability to disable synchronisation on the production server, stopping database changes going through without a implemented migration.

By default, no changes are required by any user to currently uses the current .env file. The production server should configure the `DB_SYNC` to  be `false` to stop changes without a migration. @SYNTAG This should be configured on the production box.