### PR TITLE
fix: game?players=true now only gathers required user properties

### DIFF
--- a/app/controllers/game/Game.controller.ts
+++ b/app/controllers/game/Game.controller.ts
@@ -45,10 +45,11 @@ export async function show(request: GameRequest, response: Response) {
         const userRepository = getCustomRepository(UserRepository);
         const players = await userRepository.findByIds(Object.keys(game.players), {
             relations: ['connections'],
+            select: ['id', 'avatarUrl', 'username'],
         });
 
         for (const player of players) {
-            game.players[player.id] = Object.assign(player, game.players[player.id]);
+            game.players[player.id] = Object.assign(game.players[player.id], player);
         }
     }
 

--- a/test/game.controller.test.ts
+++ b/test/game.controller.test.ts
@@ -227,7 +227,9 @@ describe('game', () => {
             // How the server would merge the given users when specifying to include players.
             const mergedPlayer = JSON.stringify(
                 Object.assign(game.storage.players[player], {
-                    ...storedPlayer.toJSON(),
+                    avatarUrl: storedPlayer.avatarUrl,
+                    username: storedPlayer.username,
+                    id: storedPlayer.id,
                     connections: [],
                 })
             );


### PR DESCRIPTION
### Overview
Beforehand, more than what was required was being returned and thus exposing information to the users that should not be e.g email. Now only what is required will be returned. 