### PR TITLE
Fix: typeorm and ci builds

### DIFF
--- a/app/controllers/user/User.controller.ts
+++ b/app/controllers/user/User.controller.ts
@@ -13,7 +13,6 @@ import UserRepository from '../../repository/User.repository';
 import { AuthorizedRequest, UserRequest } from '../../request/IRequest';
 import { DATABASE_MAX_ID, USERNAME_CHANGE_MIN_DAYS } from '../../constants';
 import ApiError from '../../utils/apiError';
-import { hash } from '../../utils/hash';
 
 import { parseIntWithDefault } from '../../../test/helpers';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@babel/code-frame": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/cod-frame/-/code-frame-7.8.3.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
             "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
             "dev": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "winston": "^3.2.1"
     },
     "devDependencies": {
+        "@babel/code-frame": "^7.8.3",
         "@types/bcrypt": "^3.0.0",
         "@types/chai": "^4.2.11",
         "@types/cookie-parser": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
         "seed:password": "node -r ts-node/register ./cli/SeedPassword.ts",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:fix": "eslint . --fix --ext .js,.jsx,.ts,.tsx",
-        "typeorm": "ts-node-dev -P ./tsconfig.json ./node_modules/.bin/typeorm",
-        "migrate": "ts-node-dev ./node_modules/.bin/typeorm migration:run",
-        "migrate:revert": "ts-node ./node_modules/.bin/typeorm migration:revert"
+        "typeorm": "ts-node-dev -P ./tsconfig.json ./node_modules/typeorm/cli.js",
+        "migrate": "ts-node-dev ./node_modules/typeorm/cli.js migration:run",
+        "migrate:revert": "ts-node ./node_modules/typeorm/cli.js migration:revert"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
### Overview
This pull request fixes the issue causing `npm ci` builds to fail. Apparently, the problem was the package-lock.json has `code` spelled incorrectly in the npm registry URL.

Running `./node_modules/.bin/typeorm` causes error on Windows:
```
λ npm run migrate

> devwars-api@0.2.0 migrate D:\www\devwars\api
> ts-node-dev ./node_modules/.bin/typeorm migration:run

Using ts-node version 8.9.1, typescript version 3.8.3
D:\www\devwars\api\node_modules\.bin\typeorm:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at wrapSafe (internal/modules/cjs/loader.js:1047:16)
    at Module._compile (internal/modules/cjs/loader.js:1097:27)
    at Module._compile (D:\www\devwars\api\node_modules\source-map-support\source-map-support.js:541:25)
    at Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Object.nodeDevHook [as .js] (D:\www\devwars\api\node_modules\ts-node-dev\lib\hook.js:61:7)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Module.require (internal/modules/cjs/loader.js:1019:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (D:\www\devwars\api\node_modules\ts-node-dev\lib\wrap.js:80:1)
[ERROR] 22:59:32 SyntaxError: missing ) after argument list
```

### Notes
* Add `@babel/code-frame@7.8.3` to fix npm registry link.
* Removed unused variable `hash` complained by the linter
* Update typeorm cli to work to support Windows and Mac
  * [Reference #1](https://github.com/typeorm/typeorm/issues/2316)
  * [Reference #2](https://github.com/typeorm/typeorm/pull/3433)

### Related issues
* [Fixes #180](https://github.com/DevWars/devwars-api/issues/180)

