### PR TITLE
Feature/ban support

### DIFF
--- a/app/controllers/authentication/Authentication.controller.ts
+++ b/app/controllers/authentication/Authentication.controller.ts
@@ -336,7 +336,8 @@ export async function updatePassword(request: AuthorizedRequest, response: Respo
  * @param expectedRole The expected lower bounds role of the given user.
  */
 export function isRoleOrHigher(user: User, expectedRole: UserRole): boolean {
-    if ([UserRole.MODERATOR, UserRole.USER, UserRole.PENDING].includes(expectedRole) && user.isStaff()) return true;
+    if ([UserRole.MODERATOR, UserRole.USER, UserRole.PENDING, UserRole.BANNED].includes(expectedRole) && user.isStaff())
+        return true;
 
     if (expectedRole === UserRole.ADMIN && user.isAdministrator()) return true;
 
@@ -357,7 +358,7 @@ export function isRoleHigher(user: User, expectedRole: UserRole): boolean {
 
     // if the expected role is a user or pending, then the user has to be a
     // moderator or higher.
-    if ((expectedRole === UserRole.USER || expectedRole === UserRole.PENDING) && user.isStaff()) return true;
+    if ([UserRole.USER, UserRole.PENDING, UserRole.BANNED].includes(expectedRole) && user.isStaff()) return true;
 
     return false;
 }

--- a/app/controllers/user/User.controller.ts
+++ b/app/controllers/user/User.controller.ts
@@ -214,13 +214,13 @@ export async function updateUserById(request: AuthorizedRequest & UserRequest, r
             (!isRoleOrHigher(request.user, UserRole.MODERATOR) ||
                 !isRoleOrHigher(request.user, params.role) ||
                 !isRoleHigher(request.user, request.boundUser.role)) &&
-            request.user.role !== UserRole.ADMIN
+            !request.user.isAdministrator()
         ) {
             throw new ApiError({
                 error: `You are not authorized to change the users role to ${params.role}`,
                 code: 401,
             });
-        } else if (request.user.role !== UserRole.ADMIN && request.user.id === request.boundUser.id) {
+        } else if (!request.user.isAdministrator() && request.user.id === request.boundUser.id) {
             throw new ApiError({
                 error: 'You are not authorized to change your own role',
                 code: 401,

--- a/app/controllers/user/User.controller.ts
+++ b/app/controllers/user/User.controller.ts
@@ -227,6 +227,11 @@ export async function updateUserById(request: AuthorizedRequest & UserRequest, r
             });
         } else {
             updateRequest.role = params.role;
+
+            // If the update request is to ban the given user, ensure to kick
+            // them out of there current authenticated seasons. And thus
+            // enforcing a login which will fail due to being banned.
+            if (params.role === UserRole.BANNED) request.boundUser.token = null;
         }
     }
 

--- a/app/controllers/user/User.controller.ts
+++ b/app/controllers/user/User.controller.ts
@@ -27,7 +27,6 @@ import { isRoleHigher, isRoleOrHigher } from '../authentication/Authentication.c
 import PaginationService from '../../services/pagination.service';
 
 interface UpdateUserRequest {
-    email: string;
     username: string;
     role: UserRole;
 }
@@ -133,18 +132,12 @@ export async function getAllUsersWithPaging(request: Request, response: Response
  *
  * @apiParam {Number} user Users unique ID.
  * @apiParam {string} [username] Users updated username.
- * @apiParam {string} [email] Users updated email.
- * @apiParam {string} [password] Users updated password.
  * @apiParam {string} [role] Users updated role.
  *
  * @apiParamExample {json} Request-Example:
  *     {
  *      "username": "test-admin",
- *      "email": "test-admin@example.com",
- *      "password": "password",
- *      "token": "token",
  *      "role": "ADMIN",
- *      "lastSigned": "2019-11-20T15:51:24.690Z",
  *     }
  *
  * @apiSuccess {string} username    the username of the User.

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -14,6 +14,8 @@ import PasswordReset from './PasswordReset';
 import UserGameStats from './UserGameStats';
 
 export enum UserRole {
+    BANNED = 'BANNED',
+
     PENDING = 'PENDING',
     USER = 'USER',
     MODERATOR = 'MODERATOR',
@@ -94,6 +96,36 @@ export default class User extends BaseModel {
         this.email = email;
         this.role = role;
     }
+
+    /**
+     * Returns true if the given user is banned or not. Checks to see that the
+     * given banned bit is set on the account status or not.
+     */
+    public isBanned = (): boolean => this.role === UserRole.BANNED;
+
+    /**
+     * Returns true if the given user is pending or not. Checks to see that the
+     * given pending bit is set on the account status or not.
+     */
+    public isPending = (): boolean => this.role === UserRole.PENDING;
+
+    /**
+     * Returns true if the given user is a moderator or not. Checks to see that
+     * the given moderator bit is set on the account status or not.
+     */
+    public isModerator = (): boolean => this.role === UserRole.MODERATOR;
+
+    /**
+     * Returns true if the given user is a administrator or not. Checks to see
+     * that the given administrator bit is set on the account status or not.
+     */
+    public isAdministrator = (): boolean => this.role === UserRole.ADMIN;
+
+    /**
+     * Returns true if the given user is a staff member or not. Checks to see
+     * that the given moderator or admin bit is set on the account status or not.
+     */
+    public isStaff = (): boolean => this.isAdministrator() || this.isModerator();
 
     /**
      * Removes a collection of properties from the current user.

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -98,32 +98,27 @@ export default class User extends BaseModel {
     }
 
     /**
-     * Returns true if the given user is banned or not. Checks to see that the
-     * given banned bit is set on the account status or not.
+     * Returns true if the given user is banned or not.
      */
     public isBanned = (): boolean => this.role === UserRole.BANNED;
 
     /**
-     * Returns true if the given user is pending or not. Checks to see that the
-     * given pending bit is set on the account status or not.
+     * Returns true if the given user is in pending state or not.
      */
     public isPending = (): boolean => this.role === UserRole.PENDING;
 
     /**
-     * Returns true if the given user is a moderator or not. Checks to see that
-     * the given moderator bit is set on the account status or not.
+     * Returns true if the given user is a moderator or not.
      */
     public isModerator = (): boolean => this.role === UserRole.MODERATOR;
 
     /**
-     * Returns true if the given user is a administrator or not. Checks to see
-     * that the given administrator bit is set on the account status or not.
+     * Returns true if the given user is a administrator or not.
      */
     public isAdministrator = (): boolean => this.role === UserRole.ADMIN;
 
     /**
-     * Returns true if the given user is a staff member or not. Checks to see
-     * that the given moderator or admin bit is set on the account status or not.
+     * Returns true if the given user is a staff member or not.
      */
     public isStaff = (): boolean => this.isAdministrator() || this.isModerator();
 

--- a/app/routes/validators/user.validator.ts
+++ b/app/routes/validators/user.validator.ts
@@ -35,8 +35,6 @@ export const profileSchema = Joi.object()
 
 export const updateUserSchema = Joi.object()
     .keys({
-        email: Joi.string().email().optional(),
-
         username: Joi.string()
             .min(constants.USERNAME_MIN_LENGTH)
             .max(constants.USERNAME_MAX_LENGTH)

--- a/app/services/Verification.service.ts
+++ b/app/services/Verification.service.ts
@@ -18,9 +18,7 @@ export class VerificationService {
     public static async reset(user: User) {
         // If the given user is moderator or a admin, they should not be subject to updating user
         // role state. e.g only standard users have to go through email verification again.
-        if (user.role === UserRole.ADMIN || user.role === UserRole.MODERATOR) {
-            return;
-        }
+        if (user.isStaff()) return;
 
         const emailRepository = getCustomRepository(EmailVerificationRepository);
         await emailRepository.removeForUser(user);

--- a/test/email.controller.test.ts
+++ b/test/email.controller.test.ts
@@ -39,7 +39,7 @@ describe('Emailing', () => {
 
         it('Should update all values if specified.', async () => {
             const repository = getCustomRepository(EmailRepository);
-            const emailOptIn: any = await repository.findOne({where: {user}});
+            const emailOptIn: any = await repository.findOne({ where: { user } });
 
             chai.expect(isNil(emailOptIn)).to.be.eq(false);
 
@@ -55,7 +55,7 @@ describe('Emailing', () => {
                 .send(emailOptIn)
                 .expect(200);
 
-            const updatedOptIn: any = await repository.findOne({where: {user}});
+            const updatedOptIn: any = await repository.findOne({ where: { user } });
             chai.expect(isNil(updatedOptIn)).to.be.eq(false);
 
             // Reverse all the boolean values to the ! of its current value.
@@ -68,28 +68,28 @@ describe('Emailing', () => {
 
         it('Should not update any values if non specified.', async () => {
             const repository = getCustomRepository(EmailRepository);
-            const emailOptIn: any = await repository.findOne({where: {user}});
+            const emailOptIn: any = await repository.findOne({ where: { user } });
 
             await agent
                 .patch(`/users/${user.id}/emails/permissions`)
                 .set('Cookie', await cookieForUser(user))
                 .expect(200);
 
-            const emailOptInUpdated: any = await repository.findOne({where: {user}});
+            const emailOptInUpdated: any = await repository.findOne({ where: { user } });
             chai.expect(JSON.stringify(emailOptIn)).to.eq(JSON.stringify(emailOptInUpdated));
         });
 
         it('Should update the specified value for a given user.', async () => {
             const repository = getCustomRepository(EmailRepository);
-            const emailOptIn = await repository.findOne({where: {user}});
+            const emailOptIn = await repository.findOne({ where: { user } });
 
             await agent
                 .patch(`/users/${user.id}/emails/permissions`)
                 .set('Cookie', await cookieForUser(user))
-                .send({news: !emailOptIn.news})
+                .send({ news: !emailOptIn.news })
                 .expect(200);
 
-            const emailOptInUpdated = await repository.findOne({where: {user}});
+            const emailOptInUpdated = await repository.findOne({ where: { user } });
             chai.expect(emailOptIn.news).to.not.eq(emailOptInUpdated.news);
         });
 

--- a/test/gameSchedule.controller.test.ts
+++ b/test/gameSchedule.controller.test.ts
@@ -124,7 +124,6 @@ describe('Game-Schedule', () => {
             const Schedule = await GameScheduleSeeding.default().save();
             const user = await UserSeeding.withRole(UserRole.USER).save();
 
-
             await agent
                 .patch(`/schedules/${Schedule.id}`)
                 .set('Cookie', await cookieForUser(user))

--- a/test/user.controller.test.ts
+++ b/test/user.controller.test.ts
@@ -21,6 +21,7 @@ import Activity from '../app/models/Activity';
 import LinkedAccountRepository from '../app/repository/LinkedAccount.repository';
 import { getCustomRepository } from 'typeorm';
 import { USERNAME_CHANGE_MIN_DAYS } from '../app/constants';
+import UserRepository from '../app/repository/User.repository';
 
 const server: ServerService = new ServerService();
 let agent: SuperTest<Test> = null;
@@ -437,6 +438,35 @@ describe('user', () => {
                 .set('Cookie', await cookieForUser(userTwo))
                 .send({ username: `${user.username}1` })
                 .expect(200);
+        });
+
+        it('Should only be able to ban if Administrator', async () => {
+            const standardUser = await UserSeeding.withRole(UserRole.USER).save();
+            const moderatorUser = await UserSeeding.withRole(UserRole.MODERATOR).save();
+            const adminUser = await UserSeeding.withRole(UserRole.ADMIN).save();
+
+            await agent
+                .put(`/users/${standardUser.id}/`)
+                .set('Cookie', await cookieForUser(standardUser))
+                .send({ role: UserRole.BANNED })
+                .expect(401, { error: `You are not authorized to change the users role to ${UserRole.BANNED}` });
+
+            await agent
+                .put(`/users/${standardUser.id}/`)
+                .set('Cookie', await cookieForUser(moderatorUser))
+                .send({ role: UserRole.BANNED })
+                .expect(401, { error: `You are not authorized to change the users role to ${UserRole.BANNED}` });
+
+            await agent
+                .put(`/users/${standardUser.id}/`)
+                .set('Cookie', await cookieForUser(adminUser))
+                .send({ role: UserRole.BANNED })
+                .expect(200);
+
+            const userRepository = getCustomRepository(UserRepository);
+            const updatedUser = await userRepository.findById(standardUser.id);
+
+            chai.expect(updatedUser.role).to.be.equal(UserRole.BANNED);
         });
 
         it('Should fail if you try to update your role to a higher role than your own', async () => {


### PR DESCRIPTION
### Overview

Support for banning users has now been implemented. This is done through the user role update process and can only be performed by a moderator or administrator. When a user is banned, the account status is updated, the current authentication token is revoked, kicking the user out.  If the user try to login again it will also be revoked.

This process is easily is reverted by changing the status back to USER again.

* Simplified account checks with related methods (isBanned, isStaff, etc).
* Supporting test cases for banning.