### PR TITLE
fix: bot routes now supported for users

### DIFF
--- a/app/routes/Game.routes.ts
+++ b/app/routes/Game.routes.ts
@@ -68,7 +68,7 @@ GameRoute.post(
 
 GameRoute.post(
     '/:game/end/bot',
-    [mustBeMinimumRole(null, true), bindGameFromGameParam],
+    [mustBeAuthenticated, mustBeMinimumRole(UserRole.MODERATOR, true), bindGameFromGameParam],
     wrapAsync(LiveGameController.end)
 );
 

--- a/app/routes/GameApplication.routes.ts
+++ b/app/routes/GameApplication.routes.ts
@@ -35,7 +35,7 @@ GameApplicationRoute.post(
 
 GameApplicationRoute.post(
     '/schedule/:schedule/twitch',
-    [mustBeMinimumRole(UserRole.MODERATOR, true), bindScheduleFromScheduleParam],
+    [mustBeAuthenticated, mustBeMinimumRole(UserRole.MODERATOR, true), bindScheduleFromScheduleParam],
     wrapAsync(GameApplicationController.applyToScheduleFromTwitch)
 );
 

--- a/app/routes/LinkedAccount.routes.ts
+++ b/app/routes/LinkedAccount.routes.ts
@@ -22,7 +22,7 @@ LinkedAccountRoute.delete('/:provider', mustBeAuthenticated, wrapAsync(LinkedAcc
 
 LinkedAccountRoute.put(
     '/twitch/coins',
-    [mustBeMinimumRole(UserRole.ADMIN, true), bodyValidation(updateTwitchCoinsSchema)],
+    [mustBeAuthenticated, mustBeMinimumRole(UserRole.ADMIN, true), bodyValidation(updateTwitchCoinsSchema)],
     wrapAsync(LinkedAccountController.updateTwitchCoins)
 );
 


### PR DESCRIPTION
### Overview
Routes which only worked for bots now also work for authenticated users based on the specified role. This is due to the mustBeAuthenticated not supporting the check for bots. It now supports this check and allows for continued use.

 * A dummy user is put in place for the bot, the bot flow and authentication will have to be reflected on in the future.