### PR TITLE
feat: use pagination implementation for bulk endpoints

### DIFF
--- a/app/controllers/game/Game.controller.ts
+++ b/app/controllers/game/Game.controller.ts
@@ -57,10 +57,68 @@ export async function show(request: GameRequest, response: Response) {
     return response.json(game);
 }
 
-export async function all(request: Request, response: Response) {
-    const games = await Game.find({ order: { createdAt: 'DESC' } });
+/**
+ * @api {get} /games?season=:season&status=:status Get games
+ * @apiDescription Gets all the given games.
+ * format.
+ * @apiName GetGames
+ * @apiVersion 1.0.0
+ * @apiGroup Games
+ *
+ * @apiParam {number {1..100}} [first=20] The number of games to return for the given page.
+ * @apiParam {number {0..}} [after=0] The point of which the games should be gathered after.
+ * @apiParam {string=scheduled,active,ended} [status] The optional game status to filter by.
+ * @apiParam {number {1..3}} [season] The optional specified season which the games are related too.
+ *
+ * @apiSuccess {Game[]} data The related games based on the provided season and page range.
+ * @apiSuccess {object} pagination The paging information to continue forward or backward.
+ * @apiSuccess {string} pagination.next The next page in the paging of the data.
+ * @apiSuccess {string} pagination.previous The previous page in the paging of the data.
+ *
+ * @apiSuccessExample Success-Response: HTTP/1.1 200 OK
+ * {
+ *   "data": [
+ *     { ... }
+ *   ],
+ *   "pagination": {
+ *     "next": "bmV4dF9fODM=",
+ *      "previous": null
+ *   }
+ * }
+ *
+ * @apiError {error} InvalidSeasonId The given season <code>id</code> provided is not valid, e.g
+ * empty or not a valid number.
+ */
+export async function gatheringAllGamesWithPaging(request: Request, response: Response) {
+    const { after, before, first, status: queryStatus, season } = request.query;
 
-    response.json(games.map((game) => flattenGame(game)));
+    const status = parseStringWithDefault(queryStatus, null);
+
+    const params = {
+        first: parseIntWithDefault(first, 20, 1, 100),
+        season: parseIntWithDefault(season, null, 1, DATABASE_MAX_ID),
+        status: parseEnumFromValue(GameStatus, _.isNil(status) ? status : status.toUpperCase(), null),
+    };
+
+    const gameRepository = getCustomRepository(GameRepository);
+    const where: any = {};
+
+    if (!_.isNil(params.status)) where.status = params.status;
+    if (!_.isNil(params.season)) where.season = params.season;
+
+    const result: any = await PaginationService.pageRepository<Game>(
+        gameRepository,
+        params.first,
+        after as string,
+        before as string,
+        'id',
+        true,
+        [],
+        where
+    );
+
+    result.data = _.map(result.data, (game) => flattenGame(game));
+    return response.json(result);
 }
 
 export async function update(request: AuthorizedRequest & GameRequest, response: Response) {
@@ -99,20 +157,6 @@ export async function latest(request: Request, response: Response) {
     // ensure that if we don't have any future games, (meaning that there are no games in the
     // database at all) that we let the user know that no games exist..
     if (_.isNil(game)) throw new ApiError({ code: 404, error: 'Currently no future games exist.' });
-
-    return response.json(flattenGame(game));
-}
-
-export async function active(request: Request, response: Response) {
-    const gameRepository = getCustomRepository(GameRepository);
-    const game = await gameRepository.active(['schedule']);
-
-    if (_.isNil(game)) {
-        throw new ApiError({
-            error: 'There currently is no active game.',
-            code: 404,
-        });
-    }
 
     return response.json(flattenGame(game));
 }
@@ -247,77 +291,6 @@ export async function create(request: CreateGameRequest, response: Response) {
     await schedule.save();
 
     return response.status(201).json(flattenGame(game));
-}
-
-/**
- * @api {get} /games/season/:season?status=:status Get games by season with pagination.
- * @apiDescription Gets all the given games for a given season in a paging
- * format.
- * @apiName GetGamesBySeason
- * @apiVersion 1.0.0
- * @apiGroup Games
- *
- * @apiParam {number} season The specified season which the games are related too.
- * @apiParam {number {1..100}} [first=20] The number of games to return for the given page.
- * @apiParam {number {0..}} [after=0] The point of which the games should be gathered after.
- * @apiParam {string=scheduled,active,ended} [status] The optional game status to filter by.
- *
- * @apiSuccess {Game[]} data The related games based on the provided season and page range.
- * @apiSuccess {object} pagination The paging information to continue forward or backward.
- * @apiSuccess {string} pagination.next The next page in the paging of the data.
- * @apiSuccess {string} pagination.previous The previous page in the paging of the data.
- *
- * @apiSuccessExample Success-Response: HTTP/1.1 200 OK
- * {
- *   "data": [
- *     { ... }
- *   ],
- *   "pagination": {
- *     "next": "bmV4dF9fODM=",
- *      "previous": null
- *   }
- * }
- *
- * @apiError {error} InvalidSeasonId The given season <code>id</code> provided is not valid, e.g
- * empty or not a valid number.
- */
-export async function findAllBySeason(request: Request, response: Response) {
-    const { after, before, first, status: queryStatus } = request.query;
-    const { season } = request.params;
-
-    const status = parseStringWithDefault(queryStatus, null);
-
-    const params = {
-        first: parseIntWithDefault(first, 20, 1, 100),
-        season: parseIntWithDefault(season, null, 1, DATABASE_MAX_ID),
-        status: parseEnumFromValue(GameStatus, _.isNil(status) ? status : status.toUpperCase(), null),
-    };
-
-    if (_.isNil(params.season)) {
-        throw new ApiError({
-            error: 'Invalid season id provided.',
-            code: 400,
-        });
-    }
-
-    const gameRepository = getCustomRepository(GameRepository);
-    const where: any = { season };
-
-    if (!_.isNil(params.status)) where.status = params.status;
-
-    const result: any = await PaginationService.pageRepository<Game>(
-        gameRepository,
-        params.first,
-        after as string,
-        before as string,
-        'id',
-        true,
-        [],
-        where
-    );
-
-    result.data = _.map(result.data, (game) => flattenGame(game));
-    return response.json(result);
 }
 
 /**

--- a/app/repository/Game.repository.ts
+++ b/app/repository/Game.repository.ts
@@ -10,10 +10,6 @@ export default class GameRepository extends Repository<Game> {
         return this.findOne({ order: { createdAt: 'DESC' } });
     }
 
-    public active(relations: string[]): Promise<Game> {
-        return this.findOne({ where: { status: GameStatus.ACTIVE }, relations });
-    }
-
     public findAllBySeason(season: number): Promise<Game[]> {
         return this.find({ where: { season }, order: { createdAt: 'DESC' } });
     }

--- a/app/routes/Game.routes.ts
+++ b/app/routes/Game.routes.ts
@@ -19,7 +19,7 @@ import { bodyValidation } from './validators';
 
 const GameRoute: express.Router = express.Router();
 
-GameRoute.get('/', wrapAsync(GameController.all));
+GameRoute.get('/', wrapAsync(GameController.gatheringAllGamesWithPaging));
 
 GameRoute.post(
     '/',
@@ -28,7 +28,6 @@ GameRoute.post(
 );
 
 GameRoute.get('/latest', wrapAsync(GameController.latest));
-GameRoute.get('/active', wrapAsync(GameController.active));
 GameRoute.get('/:game', [bindGameFromGameParam], wrapAsync(GameController.show));
 
 GameRoute.patch(
@@ -93,7 +92,5 @@ GameRoute.delete(
     ],
     wrapAsync(LiveGameController.removePlayer)
 );
-
-GameRoute.get('/season/:season', wrapAsync(GameController.findAllBySeason));
 
 export { GameRoute };

--- a/app/routes/GameSchedule.routes.ts
+++ b/app/routes/GameSchedule.routes.ts
@@ -10,7 +10,7 @@ import { bindScheduleFromScheduleParam } from '../middleware/GameSchedule.middle
 
 const GameScheduleRoute: express.Router = express.Router();
 
-GameScheduleRoute.get('/', wrapAsync(GameScheduleController.all));
+GameScheduleRoute.get('/', wrapAsync(GameScheduleController.getAllSchedulesWithPaging));
 
 GameScheduleRoute.post(
     '/',
@@ -49,7 +49,5 @@ GameScheduleRoute.post(
     [mustBeAuthenticated, mustBeMinimumRole(UserRole.MODERATOR), bindScheduleFromScheduleParam],
     wrapAsync(GameScheduleController.activate)
 );
-
-GameScheduleRoute.get('/status/:status', wrapAsync(GameScheduleController.byStatus));
 
 export { GameScheduleRoute };

--- a/cli/seed.passwords.ts
+++ b/cli/seed.passwords.ts
@@ -10,10 +10,21 @@ let connection: typeConnection;
 const updateUserPasswords = async (): Promise<any> => {
     const users = await User.find();
 
+    const password = await hash('secret');
+
+    let count = 0;
+
     for (const user of users) {
-        user.password = await hash('secret');
+        count += 1;
+
+        process.stdout.cursorTo(0);
+        process.stdout.write(`updating ${count}/${users.length} users`);
+
+        user.password = password;
         await user.save();
     }
+
+    process.stdout.write('\n');
 };
 
 (async (): Promise<any> => {

--- a/test/game.controller.test.ts
+++ b/test/game.controller.test.ts
@@ -171,14 +171,18 @@ describe('game', () => {
             }
         });
 
-        it('Should return if a given season id is larger than the database max or less than one, working as if no season was given', async () => {
-            await GameSeeding.default().save();
+        it(
+            'Should return if a given season id is larger than the database max' +
+                'or less than one, working as if no season was given',
+            async () => {
+                await GameSeeding.default().save();
 
-            for (const season of [0, -10, DATABASE_MAX_ID + 1]) {
-                const response = await agent.get(`/games?season=${season}&first=1`).expect(200);
-                chai.expect(response.body.data.length).to.be.equal(1);
+                for (const season of [0, -10, DATABASE_MAX_ID + 1]) {
+                    const response = await agent.get(`/games?season=${season}&first=1`).expect(200);
+                    chai.expect(response.body.data.length).to.be.equal(1);
+                }
             }
-        });
+        );
 
         it('Should be able to gather a season by id if it exists', async () => {
             await connectionManager.transaction(async (transaction) => {

--- a/test/gameSchedule.controller.test.ts
+++ b/test/gameSchedule.controller.test.ts
@@ -40,6 +40,20 @@ describe('Game-Schedule', () => {
     });
 
     describe('GET - /schedules - Gathering all schedules', () => {
+        it('Should return a list of schedules by status', async () => {
+            const gameStates = [GameStatus.ACTIVE, GameStatus.ACTIVE, GameStatus.ENDED, GameStatus.SCHEDULED];
+
+            await connectionManager.transaction(async (transaction) => {
+                for (const state of gameStates) {
+                    const schedule = GameScheduleSeeding.default().withStatus(state).gameSchedule;
+                    await transaction.save(schedule);
+                }
+            });
+
+            const request = await agent.get('/schedules?status=active').expect(200);
+            chai.expect(request.body.data).to.have.lengthOf(2);
+        });
+
         it('Should retrieve all schedules', async () => {
             const scheduleOne = GameScheduleSeeding.default().gameSchedule;
             const scheduleTwo = GameScheduleSeeding.default().gameSchedule;
@@ -50,7 +64,7 @@ describe('Game-Schedule', () => {
             });
 
             const response = await agent.get('/schedules').send();
-            chai.expect(response.body.length).to.be.equal(2);
+            chai.expect(response.body.data.length).to.be.equal(2);
         });
     });
 
@@ -261,22 +275,6 @@ describe('Game-Schedule', () => {
                     .set('Cookie', await cookieForUser(user))
                     .expect(202);
             }
-        });
-    });
-
-    describe('GET - /schedules/status/:status - Gathering schedules by status', () => {
-        it('Should return a list of schedules by status', async () => {
-            const gameStates = [GameStatus.ACTIVE, GameStatus.ACTIVE, GameStatus.ENDED, GameStatus.SCHEDULED];
-
-            await connectionManager.transaction(async (transaction) => {
-                for (const state of gameStates) {
-                    const schedule = GameScheduleSeeding.default().withStatus(state).gameSchedule;
-                    await transaction.save(schedule);
-                }
-            });
-
-            const request = await agent.get('/schedules/status/active').expect(200);
-            chai.expect(request.body).to.have.lengthOf(2);
         });
     });
 


### PR DESCRIPTION
### Overview
Taken the implemented paging support and applied to services that return bulk data, schedules, games, users. Supporting status for schedule and games, and season for games. This results in other endpoints being removed since they are no longer required.

 * Updated supporting tests for games, schedules and users.
 * This goes inline with: https://github.com/DevWars/devwars.tv/pull/91 request.