### PR TITLE
fix: ensure client id is provided when gathering authenticated user

### DIFF
--- a/app/services/twitch.service.ts
+++ b/app/services/twitch.service.ts
@@ -45,6 +45,7 @@ export class TwitchService {
             const response = await axios.get(userEndpoint, {
                 headers: {
                     Authorization: `Bearer ${token}`,
+                    'Client-ID': process.env.TWITCH_CLIENT,
                 },
             });
 


### PR DESCRIPTION
### Overview

Twitch now requires the client id to be provided when performing requests. This needs to be done to gather the authenticated users details during connection.